### PR TITLE
Bugfix: Modified the display style for the <Editor> content element to allow proper collapsing of the empty space left when using the HTML mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-## Alpha 0.1.6
+## Alpha 0.1.7
 ### Bug Fixes
-- Fix [#35](https://github.com/Mezryss/FVTT-Genesys/issues/35): Active talents with no active category were listed twice.
+- Fix [#20](https://github.com/Mezryss/FVTT-Genesys/issues/20): The HTML mode of the text editor was improperly sized.
 
 <details>
 <summary>Previous Releases</summary>
+
+## Alpha 0.1.6
+### Bug Fixes
+- Fix [#35](https://github.com/Mezryss/FVTT-Genesys/issues/35): Active talents with no active category were listed twice.
 
 ## Alpha 0.1.5
 ### Bug Fixes

--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -46,6 +46,7 @@ async function doAlphaNotice() {
 	<div style="text-align: center">@symbol[satfhd]</div>
 	<h4 style="font-family: 'Bebas Neue', sans-serif">Bug Fixes & Updates</h4>
 	<ul style="margin-top: 0">
+        <li>Fixed <a href="https://github.com/Mezryss/FVTT-Genesys/issues/20">#20</a>: The HTML mode of the text editor was improperly sized.</li>
 		<li>Fixed <a href="https://github.com/Mezryss/FVTT-Genesys/issues/35">#35</a>: Active talents with no active category were listed twice.</li>
 		<li>Fixed <a href="https://github.com/Mezryss/FVTT-Genesys/issues/36">#36</a>: Career item sheet was not showing editor view.</li>
 	</ul>

--- a/src/vue/components/Editor.vue
+++ b/src/vue/components/Editor.vue
@@ -192,7 +192,7 @@ async function save() {
 	.editor-content {
 		width: 100%;
 		height: 100%;
-		display: flex;
+		display: contents;
 		flex-direction: column;
 		flex-wrap: nowrap;
 

--- a/yaml/system.yml
+++ b/yaml/system.yml
@@ -1,7 +1,7 @@
 id: genesys
 title: Genesys
 description: (ALPHA) Unofficial implementation of EDGE Studio's Genesys RPG System.
-version: 0.1.6
+version: 0.1.7
 compatibility:
   minimum: 10
   verified: 10


### PR DESCRIPTION
This implements the solution I mention on #20 

![image](https://user-images.githubusercontent.com/1728535/227731909-2a64502d-620a-4440-acbc-f1da7e91899f.png)
