### PR TITLE
Fixes the skill check text editor enricher

### DIFF
--- a/src/enrichers.ts
+++ b/src/enrichers.ts
@@ -88,7 +88,7 @@ export function register() {
 		 * Enricher to add skill check links in the document.
 		 */
 		{
-			pattern: /@skill-check\[(?<skill>.+),(?<difficulty>\d)]/gim,
+			pattern: /@skill-check\[(?<skill>.+?),(?<difficulty>\d)]/gim,
 			enricher: async (match, _) => {
 				const skill = match.groups?.['skill'];
 				const difficultyString = <string | undefined>match.groups?.['difficulty'];
@@ -96,7 +96,7 @@ export function register() {
 					return null;
 				}
 
-				const difficulty = parseInt(difficultyString ?? '2');
+				let difficulty = parseInt(difficultyString ?? '2');
 				let difficultyName: string;
 
 				switch (difficulty) {
@@ -115,8 +115,12 @@ export function register() {
 					case 4:
 						difficultyName = 'Daunting';
 						break;
+					case 5:
+						difficultyName = 'Formidable';
+						break;
 					default:
 						difficultyName = 'Impossible';
+						difficulty = 5;
 				}
 
 				const container = document.createElement('a');


### PR DESCRIPTION
While I was creating some talents I noticed a few errors on the skill check enricher. Here's what I typed:
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/131e21f5-fbce-4dbf-8ad5-8c47a30fc482)

And this was the result:
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/94504098-9e65-4ef0-96ca-efada8f48ef7)

Difficulty 5 was incorrectly being labeled as "Impossible" instead of "Formidable". I made changes to fix this and also to cap the amount of dice at 5 for "Impossible".

Additionally, if two skill checks were used on the same sentence the regex kept matching everything between both of them. I changed it to be less greedy.

Here's how it looks now with the changes:
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/86341bcd-9885-4832-8046-35329b556067)