### PR TITLE
Make case errors in names more obvious

### DIFF
--- a/src/vue/sheets/actor/AdversarySheet.vue
+++ b/src/vue/sheets/actor/AdversarySheet.vue
@@ -367,6 +367,10 @@ onBeforeUpdate(updateEffects);
 			&:focus {
 				border-bottom: 1px solid colors.$dark-blue;
 			}
+
+            &:focus {
+                font-family: 'Modesto Condensed', sans-serif;
+			}
 		}
 	}
 

--- a/src/vue/sheets/item/BasicItemSheet.vue
+++ b/src/vue/sheets/item/BasicItemSheet.vue
@@ -145,6 +145,10 @@ onBeforeUpdate(updateEffects);
 			&:focus {
 				border-bottom: 1px solid colors.$dark-blue;
 			}
+
+            &:focus {
+                font-family: 'Modesto Condensed', sans-serif;
+			}
 		}
 	}
 


### PR DESCRIPTION
The changes address #29 by implementing what @Lyinggod suggested. The change applies for items and adversary sheets.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/6dcafa11-6636-414b-86ce-ba2119d92cfa)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/f401592d-1620-4a0c-a406-08db5fd1a984)
