### PR TITLE
Categorize Item and Actor types with optgroups

### DIFF
--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -16,9 +16,9 @@ import { NAMESPACE as SETTINGS_NAMESPACE, register as registerSettings } from '@
 import { KEY_ALPHA_VERSION } from '@/settings/alpha';
 
 import { register as registerStoryPointTracker } from '@/app/StoryPointTracker';
-import { register as registerActors } from '@/actor';
+import { register as registerActors, AdversaryTypes } from '@/actor';
 import { register as registerEffects } from '@/effects';
-import { register as registerItems } from '@/item';
+import { register as registerItems, CharacterCreationItemTypes, EquipmentItemTypes } from '@/item';
 
 import './scss/index.scss';
 
@@ -107,4 +107,44 @@ Hooks.once('ready', async () => {
 	await doAlphaNotice();
 
 	readyConfigs();
+});
+
+function constructOptGroup(select: HTMLSelectElement, groupLabel: string, optValues?: string[]): HTMLOptGroupElement {
+	const options = select.querySelectorAll<HTMLOptionElement>(':scope > option');
+	const optgroup = document.createElement('optgroup');
+
+	optgroup.label = groupLabel;
+	optgroup.append(...Array.from(options).filter(option => !optValues || optValues.includes(option.value)));
+
+	return optgroup;
+}
+
+Hooks.on('renderDialog', (_dialog: Dialog, html: JQuery<HTMLElement>, _data: object) => {
+	const container = html[0];
+
+	// Cheks if it's the item creation dialog and categorize the options from the dropdown
+	if (container.classList.contains('dialog-item-create')) {
+		const select = container.querySelector<HTMLSelectElement>('select[name=type]');
+
+		if (select) {
+			select.append(
+				constructOptGroup(select, game.i18n.localize('Genesys.DialogGroups.Item.CharacterCreation'), CharacterCreationItemTypes),
+				constructOptGroup(select, game.i18n.localize('Genesys.DialogGroups.Item.Equipment'), EquipmentItemTypes),
+				constructOptGroup(select, game.i18n.localize('Genesys.DialogGroups.Item.Other')),
+			);
+            select.querySelector('option')!.selected = true;
+		}
+
+	// Cheks if it's the actor creation dialog and categorize the options from the dropdown
+	} else if (container.classList.contains('dialog-actor-create')) {
+		const select = container.querySelector<HTMLSelectElement>('select[name=type]');
+
+		if (select) {
+			select.append(
+				constructOptGroup(select, game.i18n.localize('Genesys.DialogGroups.Actor.Adversary'), AdversaryTypes),
+				constructOptGroup(select, game.i18n.localize('Genesys.DialogGroups.Actor.Other')),
+			);
+            select.querySelector('option')!.selected = true;
+		}
+	}
 });

--- a/src/actor/GenesysActor.ts
+++ b/src/actor/GenesysActor.ts
@@ -24,4 +24,18 @@ export default class GenesysActor<ActorDataModel extends foundry.abstract.DataMo
 
 		return super._preCreate(data, options, user);
 	}
+
+	/**
+     * Override the createDialog callback to include an unique class that identifies the created dialog.
+     * @inheritDoc
+     */
+	static override createDialog(data?: { folder?: string | undefined; } | undefined, options?: Partial<FormApplicationOptions> | undefined): Promise<ClientDocument<foundry.documents.BaseActor> | undefined> {
+		// The 'dialog' class needs to be added explicitly, otherwise it won't be added by the super call.
+		const touchedOptions = {
+			...options,
+			classes: [...(options?.classes ?? []), 'dialog', 'dialog-actor-create']
+		};
+
+		return super.createDialog(data, touchedOptions);
+	}
 }

--- a/src/actor/index.ts
+++ b/src/actor/index.ts
@@ -20,6 +20,12 @@ export function register() {
 	registerSheets();
 }
 
+export const AdversaryTypes = [
+	'minion',
+	'nemesis',
+	'rival',
+];
+
 function registerDataModels() {
 	CONFIG.Actor.systemDataModels.character = CharacterDataModel;
 	CONFIG.Actor.systemDataModels.minion = MinionDataModel;

--- a/src/item/GenesysItem.ts
+++ b/src/item/GenesysItem.ts
@@ -21,9 +21,27 @@ export default class GenesysItem<ItemDataModel extends foundry.abstract.DataMode
 		return <ItemDataModel>this.system;
 	}
 
+	/**
+	 * Override the _preCreate callback to call preCreate from the data model class, if present.
+	 * @inheritDoc
+	 */
 	protected override async _preCreate(data: PreDocumentId<this['_source']>, options: DocumentModificationContext<this>, user: foundry.documents.BaseUser) {
 		await (<IHasPreCreate<this>>this.systemData).preCreate?.(this, data, options, user);
 
 		return super._preCreate(data, options, user);
+	}
+
+	/**
+     * Override the createDialog callback to include an unique class that identifies the created dialog.
+     * @inheritDoc
+     */
+	static override createDialog(data?: { folder?: string | undefined; } | undefined, options?: Partial<FormApplicationOptions> | undefined): Promise<ClientDocument<foundry.documents.BaseItem> | undefined> {
+		// The 'dialog' class needs to be added explicitly, otherwise it won't be added by the super call.
+		const touchedOptions = {
+			...options,
+			classes: [...(options?.classes ?? []), 'dialog', 'dialog-item-create']
+		};
+
+		return super.createDialog(data, touchedOptions);
 	}
 }

--- a/src/item/index.ts
+++ b/src/item/index.ts
@@ -28,6 +28,23 @@ export function register() {
 	registerSheets();
 }
 
+export const CharacterCreationItemTypes = [
+	'ability',
+	'archetype',
+	'career',
+	'skill',
+	'talent',
+];
+
+export const EquipmentItemTypes = [
+	'armor',
+	'consumable',
+	'container',
+	'gear',
+	'quality',
+	'weapon',
+];
+
 function registerDataModels() {
 	CONFIG.Item.systemDataModels.ability = AbilityDataModel;
 	CONFIG.Item.systemDataModels.archetype = ArchetypeDataModel;

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -245,6 +245,17 @@ Genesys:
     Long: Long
     Extreme: Extreme
 
+  # Dialog Groups
+  DialogGroups:
+    Item:
+      CharacterCreation: Character Creation
+      Equipment: Equipment
+      Other: Other
+    Actor:
+      Adversary: Adversary
+      Other: Other
+
+
   # Misc. Unsorted Labels (to be cleaned up later)
   Labels:
     Name: Name


### PR DESCRIPTION
First, a couple of pics of how it looks:
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/ccbba5f8-7860-489f-8a90-aff76e868255)

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/0aa4252e-5f7b-43cb-872e-2169be084d8b)

Now, a few things:
- I made a bunch of assumptions about your codding standards, style and structure so hopefully this matches what you're going for.
- Similarly, I made some assumptions about the categories you had in mind and even expanded it to the Actors dialog. I'm not sure how you plan to model vehicles but I assumed they might be modeled as actors.
- There's some repeated code on the Hook, but in my mind abstracting/extracting it would require for the localized string and list of options to be passed as an ordered map. That seemed like too much for what it's actually doing but ymmv, let me know if you would prefer that.
- I followed the PF2 pattern and appended a class to the dialog and that's what I'm using to detect which dialog is open. Alternatively I could find the select and check the options on it but that seemed finicky compared to this solution.