### PR TITLE
Bugfix: Add up all containers bonus encumbrance

### DIFF
--- a/src/actor/data/CharacterDataModel.ts
+++ b/src/actor/data/CharacterDataModel.ts
@@ -151,7 +151,7 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 	#additionalEncumbranceThreshold() {
 		return (<CharacterActor>(<unknown>this.parent)).items
 			.filter((i) => (<EquipmentItem>i).systemData.encumbrance !== undefined && (i as EquipmentItem).systemData.state !== EquipmentState.Dropped && (i as EquipmentItem).systemData.encumbrance < 0)
-			.reduce((total, i) => Math.abs((<EquipmentItem>i).systemData.encumbrance), 0);
+			.reduce((total, i) => total + Math.abs((<EquipmentItem>i).systemData.encumbrance), 0);
 	}
 
 	#effectiveEncumbranceForItem(item: EquipmentItem) {


### PR DESCRIPTION
If a character has more than one container only one of them is considered for the additional encumbrance calculation.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/e6532612-7faa-4a9f-8e24-e23a6bb6d95f)

This change fixes that behavior.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/157a1393-ea3b-4c2f-ba76-3862f886d849)
