### PR TITLE
Show chance to succeed when forming the dice pool

### DIFF
--- a/src/settings/user.ts
+++ b/src/settings/user.ts
@@ -11,6 +11,11 @@
  */
 export const KEY_USE_MAGICAL_GIRL_SYMBOLS = 'useMagicalGirlSymbols';
 
+/**
+ * Number of simulated rolls to do to calculate the dice pool success chance. A value of 0 disables the feature.
+ */
+export const KEY_DICE_POOL_APPROXIMATION = 'dicePoolApproximation';
+
 export function register(namespace: string) {
 	game.settings.register(namespace, KEY_USE_MAGICAL_GIRL_SYMBOLS, {
 		name: game.i18n.localize('Genesys.Settings.UseMagicalGirlSymbols'),
@@ -20,5 +25,14 @@ export function register(namespace: string) {
 		default: false,
 		type: Boolean,
 		requiresReload: true,
+	});
+
+	game.settings.register(namespace, KEY_DICE_POOL_APPROXIMATION, {
+		name: game.i18n.localize('Genesys.Settings.DicePoolApproximation'),
+		hint: game.i18n.localize('Genesys.Settings.DicePoolApproximationHint'),
+		scope: 'client',
+		config: true,
+		default: 0,
+		type: Number,
 	});
 }

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -43,6 +43,8 @@ Genesys:
     SkillForInjuriesHint: Name of the skill used when recovering from Critical Injuries.
     UseMagicalGirlSymbols: Use Magical Girl Symbols by MilkMyth (Client-Only)
     UseMagicalGirlSymbolsHint: Swap the Genesys symbol set for MilkMyth's Magical Girls symbol set. This will not affect other users.
+    DicePoolApproximation: Dice Pool Approximation
+    DicePoolApproximationHint: The number of simulated rolls to run in order to approximate the chance to succeed. Be mindful when increasing this number since it will have a direct impact on Foundry's performance; a good number to start is 100. If a value of 0 is provided this feature is disabled.
 
   # Tooltips
   Tooltips:
@@ -131,6 +133,8 @@ Genesys:
     Title: Dice Pool
     Roll: Roll!
     Hint: Use the dice box on the right to add, upgrade, and downgrade. Click dice in the pool to remove them!
+    Approximation: 'Chance to Succeed:'
+    ApproximationDisclaimer: The displayed probability is an approximation that uses the Monte Carlo method.
 
   # Experience Journal Labels
   XPJournal:


### PR DESCRIPTION
This PR adds a new feature to the Dice Prompt; it approximates the probability of succeeding the check given what's on the pool. This uses the Monte Carlo method to determine the probability instead of creating all the permutations since that is not feasible as the dice pool grows. Right now I'm uncertain if there's a better method given how the Genesys dice behave so give me some time to brush up on my knowledge; it's been too long since I took a statistics class. In the meantime this solution is more than acceptable.

This feature is enabled/tweaked per user since it has a direct impact on Foundry's performance. It's also possible to turn it of completely (this is the default). The Monte Carlo method works by simulating a bunch of rolls and analyzing the result, so the number the users input in the config corresponds to the amount of rolls performed.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/4859fcaf-90cd-4d64-8c68-5c2e742c80f5)

The higher the number, the better the approximation. At 500, the performance isn't impacted that much (for my desktop specs) and the results are good. Compare the calculated approximation and the real probability in the images below:
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/ced07576-8899-4ead-8ca6-245c89cc0583)
![ProbSucc](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/a300b4ed-0f5e-44be-be10-d3081f37a3e7)