### PR TITLE
Fixes editing icons on sheets in FoundryVTT v11

### DIFF
--- a/src/actor/GenesysActorSheet.ts
+++ b/src/actor/GenesysActorSheet.ts
@@ -28,6 +28,12 @@ export default class GenesysActorSheet<ActorDataModel extends foundry.abstract.D
 	override activateListeners(html: JQuery) {
 		super.activateListeners(html);
 
+        if (this.isEditable) {
+            // Foundry v10 and v11 bind this functionality differently so instead we override that behavior with our own.
+            html.find('img[data-edit]').off('click');
+            html.find('img[data-edit]').on('click', this._onEditImage.bind(this));
+        }
+
 		setTimeout(() => {
 			html.find('[data-skill-check]').on('click', async (event) => {
 				const target = $(event.delegateTarget);

--- a/src/effects/GenesysEffectSheet.ts
+++ b/src/effects/GenesysEffectSheet.ts
@@ -33,7 +33,9 @@ export default class GenesysEffectSheet extends ActiveEffectConfig {
 		super.activateListeners(html);
 
 		if (this.isEditable) {
-			html.find('img[data-edit=icon]').on('click', this._onEditImage.bind(this));
+            // Foundry v10 and v11 bind this functionality differently so instead we override that behavior with our own.
+            html.find('img[data-edit]').off('click');
+			html.find('img[data-edit]').on('click', this._onEditImage.bind(this));
 		}
 	}
 

--- a/src/item/GenesysItemSheet.ts
+++ b/src/item/GenesysItemSheet.ts
@@ -41,6 +41,14 @@ export default class GenesysItemSheet<ItemDataModel extends BaseItemDataModel = 
 		};
 	}
 
+    override activateListeners(html: JQuery<HTMLElement>): void {
+        if (this.isEditable) {
+            // Foundry v10 and v11 bind this functionality differently so instead we override that behavior with our own.
+            html.find('img[data-edit]').off('click');
+            html.find('img[data-edit]').on('click', this._onEditImage.bind(this));
+        }
+    }
+
 	/**
 	 * Add support for drop data on Item sheets.
 	 */

--- a/types/foundry/client/application/form-application/document-sheet/item-sheet.d.ts
+++ b/types/foundry/client/application/form-application/document-sheet/item-sheet.d.ts
@@ -36,4 +36,9 @@ declare class ItemSheet<TItem extends Item = Item> extends DocumentSheet<TItem> 
 	 * @param html The HTML object returned by template rendering
 	 */
 	override activateListeners(html: JQuery): void;
+
+    /**
+     * Handle changing the item image
+     */
+    protected _onEditImage(event: Event): void;
 }


### PR DESCRIPTION
Fixes #76

Tested in both v10 and v11 to ensure it doesn't mess up one or the other.