### PR TITLE
Bugfix: Foundry becomes unresponsive during combat

### DIFF
--- a/src/combat/GenesysCombat.ts
+++ b/src/combat/GenesysCombat.ts
@@ -136,9 +136,13 @@ export default class GenesysCombat extends Combat {
  */
 export function register() {
 	game.socket.on(SOCKET_NAME, async (payload: SocketPayload<ClaimInitiativeSlotData>) => {
-		if (payload.operation !== SocketOperation.ClaimInitiativeSlot || !payload.data) {
+		if (!game.user.isGM || payload.operation !== SocketOperation.ClaimInitiativeSlot || !payload.data) {
 			return;
 		}
+
+        // Only one GM should execute the rest of the code.
+        const isHub = game.users.filter(user => user.isGM && user.active).every(candidate => candidate.id >= game.user.id);
+        if (!isHub) { return; }
 
 		const combat = game.combats.get(payload.data.combatId) as GenesysCombat | undefined;
 		if (!combat) {


### PR DESCRIPTION
After playing around with the combat tracker I found out the problem. When a non-GM was claiming a spot and broadcasting that to the other clients the other clients will process the information and broadcast it again. This was causing an infinite loop of broadcasted messages. This solution makes it so that only one of the GM's clients reacts to the broadcast and claims the slot for them.

Fixes #57 