### PR TITLE
Adds equipment's damage state to the inventory tab

### DIFF
--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -260,6 +260,13 @@ Genesys:
       Adversary: Adversary
       Other: Other
 
+  # Equipment Data
+  Equipment:
+    DamageState:
+      Undamaged: Undamaged
+      Minor: Minor Damage
+      Moderate: Moderate Damage
+      Major: Major Damage
 
   # Misc. Unsorted Labels (to be cleaned up later)
   Labels:


### PR DESCRIPTION
This PR adds an icon that displays how damaged a piece of equipment is (more sad = more damaged). Left-clicking on it "upgrades" the damage, right-clicking "downgrades" it. This behavior is the same one used for the quantity icon. Additionally, I added a tooltip in case the intent of the icon is not properly conveyed.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/6b89897a-9231-4045-82d4-64256c9c0db7)

Closes #2 (hopefully this is a bit close to what you had in mind)