### PR TITLE
Adds support for super-characteristics

### DIFF
--- a/src/actor/data/AdversaryDataModel.ts
+++ b/src/actor/data/AdversaryDataModel.ts
@@ -5,7 +5,7 @@
  * @author Mezryss
  * @file Base data shared by all Adversaries.
  */
-import { CharacteristicsContainer } from '@/data/Characteristics';
+import { Characteristic, CharacteristicsContainer } from '@/data/Characteristics';
 import { Defense } from '@/data/Actors';
 
 type Motivation = {
@@ -26,6 +26,7 @@ export default abstract class AdversaryDataModel extends foundry.abstract.DataMo
 	abstract defense: Defense;
 	abstract description: string;
 	abstract motivations: Motivations;
+	abstract superCharacteristics: Set<Characteristic>;
 
 	static override defineSchema() {
 		const fields = foundry.data.fields;
@@ -63,6 +64,7 @@ export default abstract class AdversaryDataModel extends foundry.abstract.DataMo
 					description: new fields.HTMLField(),
 				}),
 			}),
+			superCharacteristics: new fields.SetField(new fields.StringField()),
 		};
 	}
 }

--- a/src/actor/data/CharacterDataModel.ts
+++ b/src/actor/data/CharacterDataModel.ts
@@ -14,7 +14,7 @@ import ArmorDataModel from '@/item/data/ArmorDataModel';
 import EquipmentDataModel, { EquipmentState } from '@/item/data/EquipmentDataModel';
 import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
 import { KEY_SKILLS_COMPENDIUM, DEFAULT_SKILLS_COMPENDIUM } from '@/settings/campaign';
-import { CharacteristicsContainer } from '@/data/Characteristics';
+import { Characteristic, CharacteristicsContainer } from '@/data/Characteristics';
 import { CombatPool, Defense } from '@/data/Actors';
 
 export const EQUIPMENT_TYPES = ['armor', 'consumable', 'container', 'gear', 'weapon'];
@@ -63,6 +63,7 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 	abstract encumbrance: Encumbrance;
 	abstract currency: number;
 	abstract notes: string;
+	abstract superCharacteristics: Set<Characteristic>;
 
 	/**
 	 * Total value for Soak (base + Brawn + Armor).
@@ -307,6 +308,7 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 				threshold: new fields.NumberField({ integer: true, initial: 0 }),
 			}),
 			currency: new fields.NumberField({ initial: 500 }),
+			superCharacteristics: new fields.SetField(new fields.StringField()),
 		};
 	}
 }

--- a/src/settings/campaign.ts
+++ b/src/settings/campaign.ts
@@ -42,6 +42,11 @@ export const DEFAULT_SKILLS_COMPENDIUM = 'genesys.crb-skills';
 export const KEY_SHOW_DAMAGE_ON_FAILURE = 'showDamageOnFailure';
 
 /**
+ * Whether to use the optional rule for super-characteristics.
+ */
+export const KEY_SUPER_CHARACTERISTICS = 'useSuperCharacteristics';
+
+/**
  * Register campaign settings.
  * @param namespace Namespace to register settings under.
  */
@@ -94,6 +99,15 @@ export function register(namespace: string) {
 	game.settings.register(namespace, KEY_SHOW_DAMAGE_ON_FAILURE, {
 		name: game.i18n.localize('Genesys.Settings.ShowDamageOnFailure'),
 		hint: game.i18n.localize('Genesys.Settings.ShowDamageOnFailureHint'),
+		scope: 'world',
+		config: true,
+		default: false,
+		type: Boolean,
+	});
+
+	game.settings.register(namespace, KEY_SUPER_CHARACTERISTICS, {
+		name: game.i18n.localize('Genesys.Settings.SuperCharacteristics'),
+		hint: game.i18n.localize('Genesys.Settings.SuperCharacteristicsHint'),
 		scope: 'world',
 		config: true,
 		default: false,

--- a/src/vue/sheets/actor/AdversarySheet.vue
+++ b/src/vue/sheets/actor/AdversarySheet.vue
@@ -115,6 +115,19 @@ function damageForWeapon(weapon: GenesysItem): number {
 	return weaponData.baseDamage + system.value.characteristics[weaponData.damageCharacteristic];
 }
 
+async function toggleSuper(characteristic: CharacteristicType) {
+	const superCharacteristics = new Set(system.value.superCharacteristics);
+	if (superCharacteristics.has(characteristic)) {
+		superCharacteristics.delete(characteristic);
+	} else {
+		superCharacteristics.add(characteristic);
+	}
+
+	await toRaw(context.data.actor).update({
+		'system.superCharacteristics': Array.from(superCharacteristics),
+	});
+}
+
 onBeforeMount(updateEffects);
 onBeforeUpdate(updateEffects);
 </script>
@@ -152,6 +165,9 @@ onBeforeUpdate(updateEffects);
 								can-edit
 								can-roll-unskilled
 								@rollUnskilled="rollUnskilled(CharacteristicType.Brawn)"
+								:is-super="system.superCharacteristics.has(CharacteristicType.Brawn)"
+								can-mark-super
+								@toggle-super="toggleSuper(CharacteristicType.Brawn)"
 							/>
 							<Characteristic
 								label="Genesys.Characteristics.Agility"
@@ -160,6 +176,9 @@ onBeforeUpdate(updateEffects);
 								can-edit
 								can-roll-unskilled
 								@rollUnskilled="rollUnskilled(CharacteristicType.Agility)"
+								:is-super="system.superCharacteristics.has(CharacteristicType.Agility)"
+								can-mark-super
+								@toggle-super="toggleSuper(CharacteristicType.Agility)"
 							/>
 							<Characteristic
 								label="Genesys.Characteristics.Intellect"
@@ -168,6 +187,9 @@ onBeforeUpdate(updateEffects);
 								can-edit
 								can-roll-unskilled
 								@rollUnskilled="rollUnskilled(CharacteristicType.Intellect)"
+								:is-super="system.superCharacteristics.has(CharacteristicType.Intellect)"
+								can-mark-super
+								@toggle-super="toggleSuper(CharacteristicType.Intellect)"
 							/>
 							<Characteristic
 								label="Genesys.Characteristics.Cunning"
@@ -176,6 +198,9 @@ onBeforeUpdate(updateEffects);
 								can-edit
 								can-roll-unskilled
 								@rollUnskilled="rollUnskilled(CharacteristicType.Cunning)"
+								:is-super="system.superCharacteristics.has(CharacteristicType.Cunning)"
+								can-mark-super
+								@toggle-super="toggleSuper(CharacteristicType.Cunning)"
 							/>
 							<Characteristic
 								label="Genesys.Characteristics.Willpower"
@@ -184,6 +209,9 @@ onBeforeUpdate(updateEffects);
 								can-edit
 								can-roll-unskilled
 								@rollUnskilled="rollUnskilled(CharacteristicType.Willpower)"
+								:is-super="system.superCharacteristics.has(CharacteristicType.Willpower)"
+								can-mark-super
+								@toggle-super="toggleSuper(CharacteristicType.Willpower)"
 							/>
 							<Characteristic
 								label="Genesys.Characteristics.Presence"
@@ -192,6 +220,9 @@ onBeforeUpdate(updateEffects);
 								can-edit
 								can-roll-unskilled
 								@rollUnskilled="rollUnskilled(CharacteristicType.Presence)"
+								:is-super="system.superCharacteristics.has(CharacteristicType.Presence)"
+								can-mark-super
+								@toggle-super="toggleSuper(CharacteristicType.Presence)"
 							/>
 						</div>
 					</div>

--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -36,6 +36,8 @@ const skills = computed(() => toRaw(context.data.actor).items.filter((i) => i.ty
 
 const skillCategories = computed(() => Array.from(new Set(skills.value.map((s) => s.systemData.category).sort((left, right) => SKILL_CATEGORY_SORT_ORDER[left] - SKILL_CATEGORY_SORT_ORDER[right]))));
 
+const canMarkSuper = computed(() => system.value.availableStartingXP > 0);
+
 const markCareerLabel = game.i18n.localize('Genesys.Labels.MarkCareerSkill');
 const unmarkCareerLabel = game.i18n.localize('Genesys.Labels.UnmarkCareerSkill');
 const freeRankUpLabel = game.i18n.localize('Genesys.Labels.FreeRankUp');
@@ -120,6 +122,19 @@ async function freeSkillRank(skill: GenesysItem<SkillDataModel>, adjustment: num
 	});
 }
 
+async function toggleSuper(characteristic: CharacteristicType) {
+	const superCharacteristics = new Set(system.value.superCharacteristics);
+	if (superCharacteristics.has(characteristic)) {
+		superCharacteristics.delete(characteristic);
+	} else {
+		superCharacteristics.add(characteristic);
+	}
+
+	await toRaw(context.data.actor).update({
+		'system.superCharacteristics': Array.from(superCharacteristics),
+	});
+}
+
 async function editSkill(skill: GenesysItem<SkillDataModel>) {
 	await toRaw(skill).sheet?.render(true);
 }
@@ -138,6 +153,9 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 				@upgrade="purchaseCharacteristic('brawn')"
 				can-roll-unskilled
 				@rollUnskilled="rollUnskilled(CharacteristicType.Brawn)"
+				:is-super="system.superCharacteristics.has(CharacteristicType.Brawn)"
+				:can-mark-super="canMarkSuper"
+				@toggle-super="toggleSuper(CharacteristicType.Brawn)"
 			/>
 
 			<Characteristic
@@ -147,6 +165,9 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 				@upgrade="purchaseCharacteristic('agility')"
 				can-roll-unskilled
 				@rollUnskilled="rollUnskilled(CharacteristicType.Agility)"
+				:is-super="system.superCharacteristics.has(CharacteristicType.Agility)"
+				:can-mark-super="canMarkSuper"
+				@toggle-super="toggleSuper(CharacteristicType.Agility)"
 			/>
 
 			<Characteristic
@@ -156,6 +177,9 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 				@upgrade="purchaseCharacteristic('intellect')"
 				can-roll-unskilled
 				@rollUnskilled="rollUnskilled(CharacteristicType.Intellect)"
+				:is-super="system.superCharacteristics.has(CharacteristicType.Intellect)"
+				:can-mark-super="canMarkSuper"
+				@toggle-super="toggleSuper(CharacteristicType.Intellect)"
 			/>
 
 			<Characteristic
@@ -165,6 +189,9 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 				@upgrade="purchaseCharacteristic('cunning')"
 				can-roll-unskilled
 				@rollUnskilled="rollUnskilled(CharacteristicType.Cunning)"
+				:is-super="system.superCharacteristics.has(CharacteristicType.Cunning)"
+				:can-mark-super="canMarkSuper"
+				@toggle-super="toggleSuper(CharacteristicType.Cunning)"
 			/>
 
 			<Characteristic
@@ -174,6 +201,9 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 				@upgrade="purchaseCharacteristic('willpower')"
 				can-roll-unskilled
 				@rollUnskilled="rollUnskilled(CharacteristicType.Willpower)"
+				:is-super="system.superCharacteristics.has(CharacteristicType.Willpower)"
+				:can-mark-super="canMarkSuper"
+				@toggle-super="toggleSuper(CharacteristicType.Willpower)"
 			/>
 
 			<Characteristic
@@ -183,6 +213,9 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 				@upgrade="purchaseCharacteristic('presence')"
 				can-roll-unskilled
 				@rollUnskilled="rollUnskilled(CharacteristicType.Presence)"
+				:is-super="system.superCharacteristics.has(CharacteristicType.Presence)"
+				:can-mark-super="canMarkSuper"
+				@toggle-super="toggleSuper(CharacteristicType.Presence)"
 			/>
 		</div>
 
@@ -242,8 +275,8 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 
 									<a
 										v-if="
-											(skill.systemData.rank < 5 && skill.systemData.career && system.availableXP >= 5 * (skill.systemData.rank + 1)) ||
-											(!skill.systemData.career && system.availableXP >= 5 * (skill.systemData.rank + 1) + 5)
+											skill.systemData.rank < 5 &&
+											((skill.systemData.career && system.availableXP >= 5 * (skill.systemData.rank + 1)) || (!skill.systemData.career && system.availableXP >= 5 * (skill.systemData.rank + 1) + 5))
 										"
 										@click="purchaseSkillRank(skill)"
 									>
@@ -309,7 +342,7 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 	}
 
 	.characteristic-field {
-		z-index: 1;
+		z-index: 2;
 	}
 }
 

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -45,6 +45,8 @@ Genesys:
     UseMagicalGirlSymbolsHint: Swap the Genesys symbol set for MilkMyth's Magical Girls symbol set. This will not affect other users.
     DicePoolApproximation: Dice Pool Approximation
     DicePoolApproximationHint: The number of simulated rolls to run in order to approximate the chance to succeed. Be mindful when increasing this number since it will have a direct impact on Foundry's performance; a good number to start is 100. If a value of 0 is provided this feature is disabled.
+    SuperCharacteristics: Super-Characteristics
+    SuperCharacteristicsHint: Allows marking characteristics as being 'super' during character creation, per the Super-Characteristics optional rule (Core Rulebook, p.251).
 
   # Tooltips
   Tooltips:
@@ -298,6 +300,8 @@ Genesys:
     NoArchetype: No archetype selected - drag one over!
     MarkCareerSkill: Mark As Career Skill
     UnmarkCareerSkill: Unmark As Career Skill
+    MarkSuperCharacteristic: Mark As Super-Characteristic
+    UnmarkSuperCharacteristic: Unmark As Super-Characteristic
     Motivations: Motivations
     Strength: Strength
     Flaw: Flaw

--- a/yaml/template.yml
+++ b/yaml/template.yml
@@ -21,6 +21,7 @@ Actor:
         melee: 0
         ranged: 0
       description: ''
+      superCharacteristics: []
     # The four motivations.
     motivations:
       strength: &motivation
@@ -69,6 +70,8 @@ Actor:
       threshold: 0
     # Amount of generic Currency the character has.
     currency: 500
+    # Characteristics that follow the optional Super-Characteristic rule
+    superCharacteristics: []
   minion:
     templates:
       - characteristics


### PR DESCRIPTION
This PR provides support for super-characteristics, an optional rule for the supper tone. To enable it the GM must go to the settings.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/7237713d-cb13-4d74-9d52-46359f4202d6)

Which allows an user to mark/unmark characteristics as super-characteristics during character creation (before all starting XP is spent) by right-clicking and selecting it from the menu. Super-characteristics are denoted by a star icon behind their value. If this style is too jarring let me know what else you have in mind. I suck at creating nice looking things 😭.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/55349680-a385-4341-84f2-5f33d3c041ee)

This option is also available to all adversaries.

When a character/adversary uses the Dice Roller Prompt to roll with any of their super-characteristic any proficiency dice can explode and add an additional one.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/b03b8778-4468-4fef-95ad-ebb098942be3)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/0a42675b-7f01-4b48-ba05-2b8645c69c2e)

As a side change, I fixed a bug with the rank-up icon still showing for skills that were already at rank 5.