### PR TITLE
Makes the tier bubble display properly

### DIFF
--- a/src/vue/sheets/item/TalentSheet.vue
+++ b/src/vue/sheets/item/TalentSheet.vue
@@ -72,5 +72,6 @@ const system = computed(() => context.data.item.systemData);
 	border: 1px dashed colors.$gold;
 	font-family: 'Roboto Slab', sans-serif;
 	font-size: 2em;
+    margin-right: 1em;
 }
 </style>


### PR DESCRIPTION
Makes the tier bubble more visible when looking at a talent via the talent sheet. Closes #90 
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/664b7a92-48fb-42c2-81f6-68e10aa5b1f0)