### PR TITLE
Use super-characteristics during initiative

### DIFF
--- a/src/actor/data/character/ExperienceJournal.ts
+++ b/src/actor/data/character/ExperienceJournal.ts
@@ -89,7 +89,7 @@ type SkillEntryData = {
 
 type NewTalentEntryData = {
 	name: string;
-    id: string;
+	id: string;
 	tier: number;
 	rank: number;
 };

--- a/src/actor/sheets/CharacterSheet.ts
+++ b/src/actor/sheets/CharacterSheet.ts
@@ -128,7 +128,6 @@ export default class CharacterSheet extends VueSheet(GenesysActorSheet<Character
 						},
 					],
 				});
-
 			} else {
 				// New talent
 				const cost = talent.systemData.tier * 5;

--- a/src/vue/sheets/item/TalentSheet.vue
+++ b/src/vue/sheets/item/TalentSheet.vue
@@ -72,6 +72,6 @@ const system = computed(() => context.data.item.systemData);
 	border: 1px dashed colors.$gold;
 	font-family: 'Roboto Slab', sans-serif;
 	font-size: 2em;
-    margin-right: 1em;
+	margin-right: 1em;
 }
 </style>


### PR DESCRIPTION
While working on some combat changes I noticed that this change was missed. Since this call is used when rolling initiative without using the Dice Prompt it was missing the proper logic to make the dice explode.

Also this PR includes some miscellaneous file changes caused by running the formatter.