### PR TITLE
Allows GMs to add extra initiative slots

### DIFF
--- a/public/templates/sidebar/combat-tracker.hbs
+++ b/public/templates/sidebar/combat-tracker.hbs
@@ -30,6 +30,9 @@
 				<a class="combat-button combat-control" data-tooltip="COMBAT.RollNPC" data-control="rollNPC" {{#unless turns}}disabled{{/unless}}>
 					<i class="fas fa-users-cog"></i>
 				</a>
+                <a class="combat-button combat-control" data-tooltip="Genesys.Tooltips.AddExtraInitiativeSlot" data-control="addInitiativeSlot" {{#unless turns}}disabled{{/unless}}>
+                    <i class="fas fa-user-plus"></i>
+                </a>
 			{{/if}}
 
 			{{#if combatCount}}
@@ -61,14 +64,14 @@
 	<ol id="combat-tracker" class="directory-list">
 		{{#each turns}}
 			{{#if claimed}}
-				<li class="combatant actor directory-item flexrow {{css}} slot-{{slotType}} claimed" data-combatant-id="{{id}}" data-slot-index="{{@index}}">
+				<li class="combatant actor directory-item flexrow {{css}} slot-{{slotType}} claimed" data-combatant-id="{{id}}" data-slot-index="{{@index}}" data-activation-id="{{activationId}}">
 					<img class="token-image" data-src="{{img}}" alt="{{name}}" />
 					<div class="token-name flexcol">
 						<h4>{{name}}</h4>
 						<div class="combatant-controls flexrow">
 							{{#if ../user.isGM}}
 								{{#if (not hasRolled)}}
-								<a class="combatant-control initiative-skill" data-tooltip="Genesys.Tooltips.CycleInitiativeSkill" data-control="cycleInitiativeSkill" data-initiative-skill="{{initiativeSkill}}">{{initiativeSkill}}</a>
+								<a class="combatant-control initiative-skill" data-tooltip="Genesys.Tooltips.CycleInitiativeSkill" data-control="cycleInitiativeSkill">{{initiativeSkill}}</a>
 								{{/if}}
 								<a class="combatant-control {{#if hidden}}active{{/if}}" data-tooltip="COMBAT.ToggleVis" data-control="toggleHidden">
 									<i class="fas fa-eye-slash"></i>
@@ -101,7 +104,7 @@
 					</div>
 				</li>
 			{{else}}
-				<li class="combatant actor directory-item flexrow {{css}} slot-{{slotType}}">
+				<li class="combatant actor directory-item flexrow {{css}} slot-{{slotType}}" data-combatant-id="{{id}}" data-activation-id="{{activationId}}">
 					<div class="token-name flexcol">
 						{{#if (and canClaim active)}}
 							<a data-claim-slot="{{@index}}">Claim This Initiative Slot</a>

--- a/src/combat/GenesysCombat.ts
+++ b/src/combat/GenesysCombat.ts
@@ -9,14 +9,40 @@
 import GenesysCombatant from '@/combat/GenesysCombatant';
 import GenesysRoller from '@/dice/GenesysRoller';
 import DicePrompt from '@/app/DicePrompt';
-import { ClaimInitiativeSlotData, emit as socketEmit, SOCKET_NAME, SocketOperation, SocketPayload } from '@/socket';
+import { Characteristic } from '@/data/Characteristics';
+import { ClaimInitiativeSlotData, emit as socketEmit, SOCKET_NAME, SocketOperation, SocketPayload, CombatSocketBaseData, UpdateInitiativeForExtraSlotData } from '@/socket';
 
 const FLAG_CLAIMANTS = 'claimants';
+const FLAG_EXTRA_SLOTS = 'extraSlots';
 
 type ClaimantData = Record<number, Record<number, string | undefined>>;
 
+type ExtraCombatSlot = {
+	activationSource: string;
+	initiative: number | null;
+	startingRound: number;
+	index: number;
+};
+
+type CombatSlotInfo = {
+	slotOrigin: GenesysCombatant;
+	initiative: number | null;
+	disposition: 'friendly' | 'neutral' | 'hostile';
+	id: string;
+};
+
+export type GenesysRollInitiativeOptions = {
+	prompt?: boolean;
+	extraSlotsRolls?: number[];
+};
+
+export type InitiativeSkill = {
+	skillName: string;
+	skillChar: Characteristic;
+};
+
 export default class GenesysCombat extends Combat {
-	initiativeSkills: string[] = [];
+	initiativeSkills: InitiativeSkill[] = [];
 
 	claimantForSlot(round: number, slot: number): string | undefined {
 		const claimants = this.getFlag('genesys', FLAG_CLAIMANTS) as ClaimantData | undefined;
@@ -58,13 +84,58 @@ export default class GenesysCombat extends Combat {
 		await this.unsetFlag('genesys', `claimants.${round}.${slot}`);
 	}
 
+	extraSlotsForRound(round: number) {
+		const extraSlots = (this.getFlag('genesys', FLAG_EXTRA_SLOTS) ?? []) as Omit<ExtraCombatSlot, 'index'>[];
+
+		return extraSlots.reduce((accum, slot, index) => {
+			if (slot.startingRound <= round) {
+				accum.push({ ...slot, index });
+			}
+			return accum;
+		}, [] as ExtraCombatSlot[]);
+	}
+
+	async addExtraSlot(combatantId: string, round: number) {
+		const extraSlots = [...((this.getFlag('genesys', FLAG_EXTRA_SLOTS) ?? []) as Omit<ExtraCombatSlot, 'index'>[])];
+
+		extraSlots.push({
+			activationSource: combatantId,
+			initiative: null,
+			startingRound: round,
+		});
+
+		await this.setFlag('genesys', FLAG_EXTRA_SLOTS, extraSlots);
+	}
+
+	async updateExtraSlotsInitiative(updates: Omit<ExtraCombatSlot, 'activationSource' | 'startingRound'>[]) {
+		const extraSlots = (this.getFlag('genesys', FLAG_EXTRA_SLOTS) ?? []) as Omit<ExtraCombatSlot, 'index'>[];
+
+		for (const update of updates) {
+			extraSlots[update.index].initiative = update.initiative;
+		}
+
+		await this.setFlag('genesys', FLAG_EXTRA_SLOTS, extraSlots);
+	}
+
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	override async rollInitiative(ids: string | string[], { formula = null, updateTurn = true, messageOptions = {} }: RollInitiativeOptions = {}, prompt: boolean = false) {
+	override async rollInitiative(ids: string | string[], { formula = null, updateTurn = true, messageOptions = {} }: RollInitiativeOptions = {}, { prompt = false, extraSlotsRolls = [] }: GenesysRollInitiativeOptions = {}) {
 		ids = typeof ids === 'string' ? [ids] : ids;
 		const currentId = this.combatant?.id;
 		const chatRollMode = game.settings.get('core', 'rollMode');
 
-		const updates: any[] = [];
+		const remainingExtraSlotsRolls = [...extraSlotsRolls];
+		const extraSlotsPerCombatant = this.extraSlotsForRound(this.round).reduce((accum, slot, index) => {
+			if (accum[slot.activationSource]) {
+				accum[slot.activationSource].push(index);
+			} else {
+				accum[slot.activationSource] = [index];
+			}
+			return accum;
+		}, {} as Record<string, number[]>);
+
+		let ignoreUpdateTurn = false;
+		const extraSlotsUpdates: { index: number; initiative: number }[] = [];
+		const combatantsUpdates: { _id: string; initiative: number }[] = [];
 		const messages: any[] = [];
 		for (const [i, id] of ids.entries()) {
 			// Combatant data
@@ -74,7 +145,7 @@ export default class GenesysCombat extends Combat {
 			}
 
 			// Initiative roll result
-			let skillName = combatant.initiativeSkillName ?? this.initiativeSkills[0] ?? 'Unskilled';
+			let skillName = combatant.initiativeSkill?.skillName ?? this.initiativeSkills[0]?.skillName ?? 'Unskilled';
 			const skillId = combatant.actor.items.find((i) => i.type === 'skill' && i.name.toLowerCase() === skillName.toLowerCase())?.id ?? '-';
 			let roll: Roll | undefined;
 
@@ -83,19 +154,33 @@ export default class GenesysCombat extends Combat {
 					const promptedRoll = await DicePrompt.promptForInitiative(combatant.actor, skillId, { startingDifficulty: 0 });
 
 					roll = promptedRoll.roll;
-					skillName = promptedRoll.skillName ?? 'Unskilled';
+					skillName = promptedRoll.skillName;
 				} catch {
 					continue;
 				}
 			}
 
 			if (!roll) {
-				roll = combatant.getInitiativeRoll(skillName);
+				const charFallback = combatant.initiativeSkill?.skillChar ?? this.initiativeSkills[0]?.skillChar;
+				roll = combatant.getInitiativeRoll(skillName, charFallback);
 			}
 
 			await roll.evaluate({ async: true });
 			const results = await GenesysRoller.parseRollResults(roll);
-			updates.push({ _id: combatant.id, initiative: results.netSuccess + results.netAdvantage / 100 });
+			const newInitiative = results.netSuccess + results.netAdvantage / 100;
+
+			if (extraSlotsPerCombatant[combatant.id]) {
+				// Check if the combatant is tied to an extra initiative slot that we want to roll.
+				const resrIndex = remainingExtraSlotsRolls.findIndex((slotId) => extraSlotsPerCombatant[combatant.id].includes(slotId));
+				if (resrIndex === -1) {
+					combatantsUpdates.push({ _id: combatant.id, initiative: newInitiative });
+				} else {
+					const extraSlotIndex = remainingExtraSlotsRolls.splice(resrIndex, 1)[0];
+					extraSlotsUpdates.push({ index: extraSlotIndex, initiative: newInitiative });
+				}
+			} else {
+				combatantsUpdates.push({ _id: combatant.id, initiative: newInitiative });
+			}
 
 			const rollData = {
 				description: game.i18n.format('Genesys.Rolls.Description.Initiative', { skill: skillName }),
@@ -116,42 +201,238 @@ export default class GenesysCombat extends Combat {
 			messages.push(chatData);
 		}
 
-		if (!updates.length) {
+		if (!messages.length) {
 			return this;
 		}
 
-		await this.updateEmbeddedDocuments('Combatant', updates);
+		if (extraSlotsUpdates.length) {
+			if (game.user.isGM) {
+				this.updateExtraSlotsInitiative(extraSlotsUpdates);
 
-		if (updateTurn && currentId) {
+				// Force a re-calculation of turns and a re-render of the tracker if there are no updates that would do it for us.
+				if (!combatantsUpdates.length) {
+					this.setupTurns();
+					this.debounceTrackerRender();
+					socketEmit(SocketOperation.UpdateCombatTracker, { combatId: this.id });
+				}
+			} else {
+				ignoreUpdateTurn = true;
+				socketEmit(SocketOperation.UpdateInitiativeForExtraSlot, {
+					combatId: this.id,
+					updates: extraSlotsUpdates,
+					updateTurn,
+				});
+			}
+		}
+
+		if (combatantsUpdates.length) {
+			await this.updateEmbeddedDocuments('Combatant', combatantsUpdates);
+		}
+
+		if (!ignoreUpdateTurn && updateTurn && currentId) {
 			await this.update({ turn: this.turns.findIndex((t) => t.id === currentId) });
 		}
 
 		await ChatMessage.implementation.create(messages);
 		return this;
 	}
+
+	async addInitiativeSlot() {
+		const controlledTokenCount = canvas.tokens.controlled.length;
+		if (controlledTokenCount !== 1) {
+			ui.notifications.warn(game.i18n.localize('Genesys.Notifications.SelectOneTokenForAction'));
+			return;
+		}
+
+		const combatant = canvas.tokens.controlled[0].combatant as GenesysCombatant;
+		if (!combatant) {
+			ui.notifications.warn(game.i18n.localize('Genesys.Notifications.TokenIsNotCombatant'));
+			return;
+		}
+
+		await this.addExtraSlot(combatant.id, this.round);
+
+		// Force a re-calculation of turns and a re-render of the tracker
+		this.setupTurns();
+		this.debounceTrackerRender();
+		socketEmit(SocketOperation.UpdateCombatTracker, { combatId: this.id });
+	}
+
+	override async resetAll() {
+		this.updateExtraSlotsInitiative(
+			this.extraSlotsForRound(this.round).map((slot) => ({
+				index: slot.index,
+				initiative: null,
+			})),
+		);
+
+		return await super.resetAll();
+	}
+
+	override async rollAll(options?: RollInitiativeOptions | undefined, onlyNPCs: boolean = false) {
+		const combatantIds = this.combatants.reduce((accum, combatant) => {
+			if (combatant.isOwner && (!onlyNPCs || combatant.isNPC) && combatant.initiative === null) {
+				accum.push(combatant.id);
+			}
+			return accum;
+		}, [] as string[]);
+
+		const extraSlotsRolls = this.extraSlotsForRound(this.round).reduce((accum, slot) => {
+			if (slot.initiative === null) {
+				const combatant = this.combatants.get(slot.activationSource) as GenesysCombatant | undefined;
+				if (combatant && combatant.isOwner && (!onlyNPCs || combatant.isNPC)) {
+					combatantIds.push(combatant.id);
+					accum.push(slot.index);
+				}
+			}
+			return accum;
+		}, [] as number[]);
+
+		return this.rollInitiative(combatantIds, options, { extraSlotsRolls });
+	}
+
+	override async rollNPC(options?: RollInitiativeOptions | undefined) {
+		return this.rollAll(options, true);
+	}
+
+	override setupTurns() {
+		const combatants = this.combatants.map(
+			(combatant) =>
+				({
+					slotOrigin: combatant as GenesysCombatant,
+					initiative: combatant.initiative,
+					disposition: (combatant as GenesysCombatant).disposition,
+					id: combatant.id,
+				} as CombatSlotInfo),
+		);
+
+		const extraActivations = this.extraSlotsForRound(this.round).reduce((accum, slot) => {
+			const combatant = this.combatants.get(slot.activationSource) as GenesysCombatant | undefined;
+			if (combatant) {
+				accum.push({
+					slotOrigin: combatant,
+					initiative: slot.initiative,
+					disposition: combatant.disposition,
+					id: combatant.id,
+				});
+			}
+			return accum;
+		}, [] as CombatSlotInfo[]);
+
+		const turns = combatants
+			.concat(extraActivations)
+			.sort(this._sortSlots)
+			.map((slotData) => slotData.slotOrigin);
+
+		if (this.turn !== null) {
+			// @ts-ignore: This assignment is exactly the same as in the original method.
+			this.turn = Math.clamped(this.turn, 0, turns.length - 1);
+		}
+
+		const currentCombatant = turns[this.turn];
+		this.current = {
+			round: this.round,
+			turn: this.turn,
+			combatantId: currentCombatant ? currentCombatant.id : null,
+			tokenId: currentCombatant ? currentCombatant.tokenId : null,
+		};
+
+		if (!this.previous) {
+			this.previous = this.current;
+		}
+
+		return (this.turns = turns as any);
+	}
+
+	protected _sortSlots(firstSlot: CombatSlotInfo, secondSlot: CombatSlotInfo) {
+		const fsInitiative = firstSlot.initiative ?? -Infinity;
+		const ssInitiative = secondSlot.initiative ?? -Infinity;
+
+		// Sort by initiative value in descending order.
+		if (fsInitiative === ssInitiative) {
+			// Break initiative ties by using the combatants' disposition.
+			if (firstSlot.disposition === secondSlot.disposition) {
+				// Break ties in the combatants' disposition by using their id.
+				if (firstSlot.id === secondSlot.id) {
+					return 0;
+				} else {
+					return firstSlot.id > secondSlot.id ? 1 : -1;
+				}
+			} else {
+				const dispositions = ['hostile', 'neutral', 'friendly'];
+				return dispositions.indexOf(secondSlot.disposition) - dispositions.indexOf(firstSlot.disposition);
+			}
+		} else {
+			return ssInitiative - fsInitiative;
+		}
+	}
+
+	/**
+	 * If this is the currently viewed encounter, re-render the CombatTracker application.
+	 * We debounce this call to allow for updates to complete.
+	 */
+	debounceTrackerRender = foundry.utils.debounce(() => {
+		if (ui.combat.viewed === this) {
+			ui.combat.render();
+		}
+	}, 50);
 }
 
 /**
  * Register socket listener for Genesys Combats
  */
 export function register() {
-	game.socket.on(SOCKET_NAME, async (payload: SocketPayload<ClaimInitiativeSlotData>) => {
-		if (!game.user.isGM || payload.operation !== SocketOperation.ClaimInitiativeSlot || !payload.data) {
-			return;
-		}
+	// Helper function to determine if the code is being executed by only one GM.
+	const isGmHub = () => {
+		return game.user.isGM && game.users.filter((user) => user.isGM && user.active).every((candidate) => candidate.id >= game.user.id);
+	};
 
-		// Only one GM should execute the rest of the code.
-		const isHub = game.users.filter((user) => user.isGM && user.active).every((candidate) => candidate.id >= game.user.id);
-		if (!isHub) {
+	game.socket.on(SOCKET_NAME, async (payload: SocketPayload<CombatSocketBaseData>) => {
+		if (!payload.data) {
 			return;
 		}
 
 		const combat = game.combats.get(payload.data.combatId) as GenesysCombat | undefined;
 		if (!combat) {
-			console.error(`Socket received Claim Initiative payload with invalid combat ID ${payload.data.combatId}`);
+			console.error(`Socket received ${SocketOperation[payload.operation]} payload with invalid combat ID ${payload.data.combatId}`);
 			return;
 		}
 
-		await combat.claimSlot(payload.data.round, payload.data.slot, payload.data.combatantId);
+		switch (payload.operation) {
+			case SocketOperation.ClaimInitiativeSlot:
+				if (!isGmHub()) {
+					return;
+				}
+
+				const cisData = payload.data as ClaimInitiativeSlotData;
+				await combat.claimSlot(cisData.round, cisData.slot, cisData.combatantId);
+				break;
+
+			case SocketOperation.UpdateCombatTracker:
+				combat.setupTurns();
+				combat.debounceTrackerRender();
+				break;
+
+			case SocketOperation.UpdateInitiativeForExtraSlot:
+				if (!isGmHub()) {
+					return;
+				}
+
+				const uifesData = payload.data as UpdateInitiativeForExtraSlotData;
+				const currentCombatantId = combat.combatant?.id;
+
+				await combat.updateExtraSlotsInitiative(uifesData.updates);
+				combat.setupTurns();
+				combat.debounceTrackerRender();
+				socketEmit(SocketOperation.UpdateCombatTracker, { combatId: uifesData.combatId });
+
+				if (uifesData.updateTurn && currentCombatantId) {
+					await combat.update({ turn: combat.turns.findIndex((combatant) => combatant.id === currentCombatantId) });
+				}
+				break;
+
+			default:
+				return;
+		}
 	});
 }

--- a/src/scss/combat-tracker.scss
+++ b/src/scss/combat-tracker.scss
@@ -9,12 +9,8 @@
 		padding-right: 0.5em;
 	}
 
-	.disposition-friendly,
-	.disposition-hostile,
-	.disposition-neutral {
-		&:not(.active) {
-			border-bottom: 1px dashed transparentize(colors.$gold, 0.6);
-		}
+	> :not(:last-child):not(.active) {
+		border-bottom: 1px dashed transparentize(colors.$gold, 0.6);
 	}
 
 	.initiative-skill {

--- a/src/socket/index.ts
+++ b/src/socket/index.ts
@@ -31,14 +31,26 @@ export enum SocketOperation {
 	 * Called when a player wants to claim an initiative slot.
 	 */
 	ClaimInitiativeSlot,
+
+	/**
+	 * Update the turns for the Combat Tracker.
+	 */
+	UpdateCombatTracker,
+
+	/**
+	 * Called when a player rolls initiative for an extra slot.
+	 */
+	UpdateInitiativeForExtraSlot,
 }
 
-export type ClaimInitiativeSlotData = {
+export type CombatSocketBaseData = {
 	/**
 	 * Combat ID to claim a slot in.
 	 */
 	combatId: string;
+};
 
+export type ClaimInitiativeSlotData = CombatSocketBaseData & {
 	/**
 	 * Combatant ID claiming the slot.
 	 */
@@ -55,6 +67,18 @@ export type ClaimInitiativeSlotData = {
 	slot: number;
 };
 
+export type UpdateInitiativeForExtraSlotData = CombatSocketBaseData & {
+	/**
+	 * An array of updates to apply to the extra initiative slots.
+	 */
+	updates: { index: number; initiative: number }[];
+
+	/**
+	 * If the combat turn should be updated after adding the new initiative values.
+	 */
+	updateTurn: boolean;
+};
+
 /**
  * Socket Payload typing
  */
@@ -62,11 +86,6 @@ export type SocketPayload<T extends { [key: string]: unknown }> = {
 	operation: SocketOperation;
 	data?: T;
 };
-
-/**
- * Claim an Initiative slot.
- */
-export function emit(operation: SocketOperation.ClaimInitiativeSlot, data: ClaimInitiativeSlotData): void;
 
 /**
  * Spend a Story Point.
@@ -77,6 +96,21 @@ export function emit(operation: SocketOperation.PlayerSpendStoryPoint): void;
  * Force the Story Point Tracker application to refresh its data.
  */
 export function emit(operation: SocketOperation.UpdateStoryPointTracker): void;
+
+/**
+ * Claim an Initiative slot.
+ */
+export function emit(operation: SocketOperation.ClaimInitiativeSlot, data: ClaimInitiativeSlotData): void;
+
+/**
+ * Refresh the Combat Tracker's data.
+ */
+export function emit(operation: SocketOperation.UpdateCombatTracker, data: CombatSocketBaseData): void;
+
+/**
+ * Update the initiative value of some extra slots.
+ */
+export function emit(operation: SocketOperation.UpdateInitiativeForExtraSlot, data: UpdateInitiativeForExtraSlotData): void;
 
 /**
  * Utility wrapper for the system's socket emits, providing type-safe argument checking for each operation.

--- a/types/foundry/client/documents/combatant.d.ts
+++ b/types/foundry/client/documents/combatant.d.ts
@@ -75,7 +75,7 @@ declare global {
 		 * @param [formula] A dice formula which overrides the default for this Combatant.
 		 * @return The Roll instance to use for the combatant.
 		 */
-		rollInitiative(formula: string): Rolled<Roll>;
+		rollInitiative(formula: string): Promise<this>;
 
 		override prepareDerivedData(): void;
 

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -53,6 +53,7 @@ Genesys:
     NoDescription: No Description Available
     IsInitiative: Whether the skill is commonly used for Initiative or not. Setting this to true will make it appear as an option in the combat tracker for mass rolls.
     CycleInitiativeSkill: Cycle which initiative skill the combatant is using.
+    AddExtraInitiativeSlot: Adds an extra initiative slot.
 
   # Dice Rolls
   Rolls:
@@ -163,6 +164,9 @@ Genesys:
     CannotDeleteExistingTalent: Cannot delete XP Journal Entry for increasing talent '{name}' to rank {rank} - you must delete the higher rank increases first!
     CannotPurchaseTalentTier: Cannot purchase talents at tier {tier} - you must have at least {minimum} talents at rank {lowerTier} first.
     NotEnoughStoryPoints: You can't spend Story Points you don't have!
+    SelectOneTokenForAction: You need to selected a single token to perform this action.
+    TokenIsNotCombatant: The selected token is not participating on the current combat.
+    CannotClaimOppositeSlot: You can't claim this initiative slot with {name} - it's on the wrong side!
 
   # Story Points
   StoryPoints:


### PR DESCRIPTION
This PR allows GMs to add extra initiative slots during combat. The new initiative slot is tied to a combatant that is already part of the combat. The combatant needs to roll initiative for the extra slot as well; this can be very useful if the GM is using the nemesis extra activation optional rule.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/7fe6c3b2-119d-4d4c-a028-922f1315eb0d)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/f5dac178-a2a8-41f7-a3ac-dfa794afec5c)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/1e5056f2-6b9d-4a58-a765-f99e507069b6)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/6cc2fb99-99c7-4c74-8b8c-f5e53550d653)

There are some other improvements as well:
- Fixed the CSS to show a thin border between slots in order to distinguish each slot better.
- Implement proper initiative rolling in some other areas that were missed before.
- Removed some "dead code".
- Rolling initiative for characters without an initiative skill in their sheet now considers the typical characteristic tied to said skills instead of always using Brawn. This only happened when using the Roll All/NPC options.
- Added some error messages to the language file, plus added a new one when selecting a token that is not part of the running combat.
- Rerolling was only possible if you claimed the same initiative slot that was created originally. Now it works properly.
- The turn controls, like the "End Turn" button, now show up properly when you claim a slot.