### PR TITLE
Allows rolling dice pools without dice

### DIFF
--- a/src/combat/GenesysCombat.ts
+++ b/src/combat/GenesysCombat.ts
@@ -166,7 +166,7 @@ export default class GenesysCombat extends Combat {
 			}
 
 			await roll.evaluate({ async: true });
-			const results = await GenesysRoller.parseRollResults(roll);
+			const results = GenesysRoller.parseRollResults(roll);
 			const newInitiative = results.netSuccess + results.netAdvantage / 100;
 
 			if (extraSlotsPerCombatant[combatant.id]) {

--- a/src/combat/GenesysCombatant.ts
+++ b/src/combat/GenesysCombatant.ts
@@ -40,7 +40,7 @@ export default class GenesysCombatant extends Combatant<GenesysCombat, GenesysAc
 	override async rollInitiative(formula: string) {
 		const roll = this.getInitiativeRoll(formula);
 		await roll.evaluate({ async: true });
-		const results = await GenesysRoller.parseRollResults(roll);
+		const results = GenesysRoller.parseRollResults(roll);
 
 		return this.update({ initiative: results.netSuccess + results.netAdvantage / 100 });
 	}

--- a/src/dice/GenesysRoller.ts
+++ b/src/dice/GenesysRoller.ts
@@ -80,7 +80,7 @@ export default class GenesysRoller {
 	static async skillRoll({ actor, characteristic, skillId, formula, symbols }: { actor?: GenesysActor; characteristic?: Characteristic; skillId: string; formula: string; symbols: Record<string, number> }) {
 		const roll = new Roll(formula, { symbols });
 		await roll.evaluate({ async: true });
-		const results = await this.parseRollResults(roll);
+		const results = this.parseRollResults(roll);
 
 		let description: string | undefined = undefined;
 
@@ -137,7 +137,7 @@ export default class GenesysRoller {
 	}) {
 		const roll = new Roll(formula, { symbols });
 		await roll.evaluate({ async: true });
-		const results = await this.parseRollResults(roll);
+		const results = this.parseRollResults(roll);
 
 		let description: string | undefined = undefined;
 
@@ -205,7 +205,7 @@ export default class GenesysRoller {
 		await ChatMessage.create(chatData);
 	}
 
-	static async parseRollResults(roll: Roll): Promise<GenesysRollResults> {
+	static parseRollResults(roll: Roll): GenesysRollResults {
 		const faces = roll.dice.reduce((faces: Record<string, string[]>, die) => {
 			const genDie = <GenesysDie>die;
 			if (faces[genDie.denomination] === undefined) {

--- a/src/vue/apps/DicePrompt.vue
+++ b/src/vue/apps/DicePrompt.vue
@@ -273,7 +273,7 @@ function compileDicePool() {
 		.join('+');
 
 	return {
-		formula,
+		formula: formula === '' ? '0' : formula,
 		usesSuperCharacteristic: (useSuperCharacteristic && dice['P']) as boolean,
 		dice,
 		symbols,
@@ -352,6 +352,13 @@ async function approximateProbability() {
 		usesSuperCharacteristic,
 	};
 
+	// Slight optimization for a pool without dice.
+	if (!Object.keys(dice).length) {
+		const deterministicResult = (symbols.s ?? 0) > (symbols.f ?? 0) ? 100 : 0;
+		successApproximation.value = deterministicResult.toFixed(2);
+		return;
+	}
+
 	// No need to run this process again if nothing of importance has changed.
 	if (hasSameChanceToSucceed(previousDicePool, currentDicePool)) {
 		return;
@@ -361,7 +368,7 @@ async function approximateProbability() {
 		[...Array(DICE_POOL_APPROXIMATION)].map(async () => {
 			const roll = new Roll(formula, { symbols });
 			const result = await roll.evaluate({ async: true });
-			return await GenesysRoller.parseRollResults(result);
+			return GenesysRoller.parseRollResults(result);
 		}),
 	);
 


### PR DESCRIPTION
When approximating the success probability of an empty (no-dice) dice pool the system will throw an error. The same will happen if you try to roll said pool. This PR fixes that issue and allows rolling said pools since they aren't technically against the rules.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/97356ed8-219c-4389-8285-f84450f592f3)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/71399c96-0d21-430b-8533-80ea47f76077)