### PR TITLE
Adds alternate way to calculate chance to succeed

### DIFF
--- a/public/scripts/calculate-chance-worker.js
+++ b/public/scripts/calculate-chance-worker.js
@@ -1,0 +1,536 @@
+/**
+ * This class represents a symbol that might appear on a die face.
+ * @class
+ */
+class GenesysSymbol {
+	#denomination;
+	#opposes;
+	#alsoIn;
+
+	/**
+	 * @param {Object} symbolData - An object with data necessary for creating a symbol.
+	 * @param {string} symbolData.denomination - A character that represents the symbol.
+	 * @param {GenesysSymbol=} symbolData.opposes - Another symbol that opposes this one.
+	 * @param {GenesysSymbol=} symbolData.alsoIn - Another symbol that is also treated as this one.
+	 */
+	constructor({ denomination, opposes, alsoIn }) {
+		this.#denomination = denomination;
+		this.#opposes = opposes;
+		this.#alsoIn = alsoIn;
+
+		// Both symbols are each other's opposite.
+		if (opposes) {
+			opposes.#opposes = this;
+		}
+	}
+
+	get denomination() {
+		return this.#denomination;
+	}
+
+	get opposes() {
+		return this.#opposes;
+	}
+
+	get alsoIn() {
+		return this.#alsoIn;
+	}
+}
+
+/**
+ * An object containing all the possible symbols that can appear on a dice face.
+ * @type Record<string, GenesysSymbol>
+ */
+const Symbols = {};
+Symbols.Triumph = new GenesysSymbol({ denomination: 't' });
+Symbols.Advantage = new GenesysSymbol({ denomination: 'a' });
+Symbols.Success = new GenesysSymbol({ denomination: 's', alsoIn: Symbols.Triumph });
+
+Symbols.Despair = new GenesysSymbol({ denomination: 'd' });
+Symbols.Threat = new GenesysSymbol({ denomination: 'h', opposes: Symbols.Advantage });
+Symbols.Failure = new GenesysSymbol({ denomination: 'f', opposes: Symbols.Success, alsoIn: Symbols.Despair });
+
+// A map of symbol denominations to their instances.
+const SymbolFromDenomination = new Map(Object.values(Symbols).map((symbol) => [symbol.denomination, symbol]));
+
+/**
+ * This class represents one of the faces of a die.
+ * @class
+ */
+class GenesysDieFace {
+	#symbols;
+
+	/**
+	 * @param {GenesysSymbol[]} symbols - A list of symbols on this die face.
+	 */
+	constructor(symbols) {
+		this.#symbols = symbols;
+	}
+
+	toCompactString() {
+		const symbols = {};
+		this.#symbols.forEach((symbol) => {
+			const charSymbol = symbol.denomination;
+			symbols[charSymbol] = 1 + (symbols[charSymbol] ?? 0);
+		});
+
+		return Object.keys(symbols)
+			.sort()
+			.map((symbolDenom) => `${symbols[symbolDenom]}${symbolDenom}`)
+			.join('');
+	}
+}
+
+/**
+ * This class represents a dice.
+ * @class
+ */
+class GenesysDie {
+	#denomination;
+	#faces;
+
+	/**
+	 *
+	 * @param {Object} dieData - An object with data necessary for creating a die.
+	 * @param {string} dieData.denomination - A character that represents the die.
+	 * @param {GenesysDieFace[]} dieData.faces - A list of faces on this die.
+	 */
+	constructor({ denomination, faces }) {
+		this.#denomination = denomination;
+		this.#faces = faces;
+	}
+
+	get denomination() {
+		return this.#denomination;
+	}
+
+	get faces() {
+		return this.#faces;
+	}
+}
+
+/**
+ * An object containing all the possible dice that can appear on a pool.
+ * @type Record<string, GenesysDie>
+ */
+const Dice = {
+	Boost: new GenesysDie({
+		denomination: 'B',
+		faces: [
+			new GenesysDieFace([]),
+			new GenesysDieFace([]),
+			new GenesysDieFace([Symbols.Success]),
+			new GenesysDieFace([Symbols.Success, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Advantage, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Advantage]),
+		],
+	}),
+	Ability: new GenesysDie({
+		denomination: 'A',
+		faces: [
+			new GenesysDieFace([]),
+			new GenesysDieFace([Symbols.Success]),
+			new GenesysDieFace([Symbols.Success]),
+			new GenesysDieFace([Symbols.Success, Symbols.Success]),
+			new GenesysDieFace([Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Success, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Advantage, Symbols.Advantage]),
+		],
+	}),
+	Proficiency: new GenesysDie({
+		denomination: 'P',
+		faces: [
+			new GenesysDieFace([]),
+			new GenesysDieFace([Symbols.Success]),
+			new GenesysDieFace([Symbols.Success]),
+			new GenesysDieFace([Symbols.Success, Symbols.Success]),
+			new GenesysDieFace([Symbols.Success, Symbols.Success]),
+			new GenesysDieFace([Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Success, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Success, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Success, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Advantage, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Advantage, Symbols.Advantage]),
+			new GenesysDieFace([Symbols.Triumph]),
+		],
+	}),
+
+	Setback: new GenesysDie({
+		denomination: 'S',
+		faces: [new GenesysDieFace([]), new GenesysDieFace([]), new GenesysDieFace([Symbols.Failure]), new GenesysDieFace([Symbols.Failure]), new GenesysDieFace([Symbols.Threat]), new GenesysDieFace([Symbols.Threat])],
+	}),
+	Difficulty: new GenesysDie({
+		denomination: 'D',
+		faces: [
+			new GenesysDieFace([]),
+			new GenesysDieFace([Symbols.Failure]),
+			new GenesysDieFace([Symbols.Failure, Symbols.Failure]),
+			new GenesysDieFace([Symbols.Threat]),
+			new GenesysDieFace([Symbols.Threat]),
+			new GenesysDieFace([Symbols.Threat]),
+			new GenesysDieFace([Symbols.Threat, Symbols.Threat]),
+			new GenesysDieFace([Symbols.Failure, Symbols.Threat]),
+		],
+	}),
+	Challenge: new GenesysDie({
+		denomination: 'C',
+		faces: [
+			new GenesysDieFace([]),
+			new GenesysDieFace([Symbols.Failure]),
+			new GenesysDieFace([Symbols.Failure]),
+			new GenesysDieFace([Symbols.Failure, Symbols.Failure]),
+			new GenesysDieFace([Symbols.Failure, Symbols.Failure]),
+			new GenesysDieFace([Symbols.Threat]),
+			new GenesysDieFace([Symbols.Threat]),
+			new GenesysDieFace([Symbols.Failure, Symbols.Threat]),
+			new GenesysDieFace([Symbols.Failure, Symbols.Threat]),
+			new GenesysDieFace([Symbols.Threat, Symbols.Threat]),
+			new GenesysDieFace([Symbols.Threat, Symbols.Threat]),
+			new GenesysDieFace([Symbols.Despair]),
+		],
+	}),
+};
+
+// A map of dice denominations to their instances.
+const DiceFromDenomination = new Map(Object.values(Dice).map((dice) => [dice.denomination, dice]));
+
+/**
+ * This function is used to construct the key for a simple pool (one where there is only one type of
+ * object present).
+ * @param {{denomination: string}} obj - The type of object that's on the pool.
+ * @param {number} amount - The number of objects of the provided type that are on the pool.
+ * @returns {string} A key that represents the passed pool.
+ */
+function constructKeyFromSimplePool(obj, amount) {
+	return `${amount}${obj.denomination}`;
+}
+
+/**
+ * This function is used to construct the key for a mixed pool (one where there can be more than one
+ * type of object present).
+ * @param {Map<{denomination: string}, number>} objectsPool - A map that describes the pool.
+ * @returns {string} A key that represents the passed pool.
+ */
+function constructKeyFromMixedPool(objectsPool) {
+	const sortedPool = [...objectsPool].sort(([fObj], [sObj]) => denominationSorter(fObj, sObj));
+
+	return sortedPool.map(([obj, amount]) => constructKeyFromSimplePool(obj, amount)).join('');
+}
+
+/**
+ * A function used to sort objects by their `denomination` string field.
+ * @param {{denomination: string}} first - The first object to compare.
+ * @param {{denomination: string}} second - The second object to compare.
+ * @returns {number} A number that signals the direction into which to sort the provided objects.
+ */
+function denominationSorter(first, second) {
+	if (first.denomination > second.denomination) {
+		return 1;
+	}
+	if (first.denomination < second.denomination) {
+		return -1;
+	}
+	return 0;
+}
+
+/**
+ * A singleton that creates all the possible permutations for a given dice pool. It caches these
+ * results for subsequent calls.
+ */
+const Permutations = (function () {
+	/**
+	 * This object is a cache of all the permutations calculated for simple dice pools.
+	 * @type Record<string, Record<string, number>>
+	 */
+	const cacheForSimple = {};
+
+	/**
+	 * This object is a cache of all the permutations calculated for mixed dice pools.
+	 * @type Record<string, Record<string, number>>
+	 */
+	const cacheForMixed = {};
+
+	/**
+	 * This function is used to generate a mixed dice pool given a string representation of it.
+	 * @param {string} poolString - The string representation of a dice pool.
+	 * @returns {Map<GenesysDie, number>} A map that describes the given dice pool.
+	 */
+	function generateMixedPoolFromString(poolString) {
+		const dicePool = new Map();
+		const matchedDice = [...poolString.matchAll(/(\d+)(\w)/g)];
+
+		for (const [amount, denomination] of matchedDice) {
+			dicePool.set(DiceFromDenomination.get(denomination), parseInt(amount, 10));
+		}
+
+		return dicePool;
+	}
+
+	/**
+	 * This function takes two string representation of a collection of symbols and returns a new string
+	 * that correctly combines both of them.
+	 * @param {string} firstGroup - A string representation of a collection of symbols.
+	 * @param {string} secondGroup - A string representation of a collection of symbols.
+	 * @returns {string} A string representation that counts all the symbols on the provided collections.
+	 */
+	function mergeSymbolsString(firstGroup, secondGroup) {
+		const symbols = {};
+		const matchedSymbols = [...(firstGroup + secondGroup).matchAll(/(\d+)(\w)/g)];
+		matchedSymbols.forEach(([, amount, denomination]) => {
+			symbols[denomination] = parseInt(amount, 10) + (symbols[denomination] ?? 0);
+		});
+
+		return Object.keys(symbols)
+			.sort()
+			.map((symbolDenom) => `${symbols[symbolDenom]}${symbolDenom}`)
+			.join('');
+	}
+
+	/**
+	 * This function creates all the possible permutations for pool of dice of mixed type.
+	 * @param {Map<GenesysDie, number>} dicePool - The pool of dice with their types and amount.
+	 * @returns {Record<string, number>} All the permutations for the passed pool.
+	 */
+	function forMixedPool(dicePool) {
+		const poolKey = constructKeyFromMixedPool(dicePool);
+		if (cacheForMixed[poolKey]) {
+			return cacheForMixed[poolKey];
+		}
+
+		let closestCachedPoolKey = '';
+		let closestCachedPool = new Map([...dicePool.keys()].map((dice) => [dice, 0]));
+		for (const cacheKey of Object.keys(cacheForMixed)) {
+			const currentDicePool = generateMixedPoolFromString(cacheKey);
+			if (
+				dicePool.size >= currentDicePool.size &&
+				[...currentDicePool.entries()].every(([dice, amount]) => {
+					return dicePool.get(dice) >= amount && amount >= closestCachedPool.get(dice);
+				})
+			) {
+				closestCachedPoolKey = cacheKey;
+				closestCachedPool = currentDicePool;
+			}
+		}
+
+		let partialPermutations = cacheForMixed[closestCachedPoolKey] ?? {};
+		for (const [dice, amount] of dicePool) {
+			const remainingDice = amount - (closestCachedPool.get(dice) ?? 0);
+			partialPermutations = combinePermutations(partialPermutations, forSimplePool(dice, remainingDice));
+		}
+
+		cacheForMixed[poolKey] = partialPermutations;
+		return partialPermutations;
+	}
+
+	/**
+	 * This function creates all the possible permutations for pool of dice of only one type.
+	 * @param {GenesysDie} dice - The type of dice that's on the pool.
+	 * @param {number} amount - The number of dice of the provided type that are on the pool.
+	 * @returns {Record<string, number>} All the permutations for the passed pool.
+	 */
+	function forSimplePool(dice, amount) {
+		const poolKey = constructKeyFromSimplePool(dice, amount);
+
+		if (cacheForSimple[poolKey]) {
+			return cacheForSimple[poolKey];
+		} else if (amount === 1) {
+			// For only one dice just go through all the faces and aggregate those that are the same.
+			cacheForSimple[poolKey] = dice.faces.reduce((accum, face) => {
+				const permutation = face.toCompactString();
+				accum[permutation] = 1 + (accum[permutation] ?? 0);
+				return accum;
+			}, {});
+
+			return cacheForSimple[poolKey];
+		} else if (amount > 1) {
+			// For more than one dice find the permutations for half the pool and then combine them.
+			const largeHalf = Math.ceil(amount / 2);
+			const smallHalf = Math.floor(amount / 2);
+			cacheForSimple[poolKey] = combinePermutations(forSimplePool(dice, largeHalf), forSimplePool(dice, smallHalf));
+
+			return cacheForSimple[poolKey];
+		}
+
+		return {};
+	}
+
+	/**
+	 * This function takes two collections of permutations and combine them together into a new collection.
+	 * @param {Record<string, number>} firstGroup - A collection of permutations.
+	 * @param {Record<string, number>} secondGroup - A collection of permutations.
+	 * @returns {Record<string, number>} A collection of permutations created by taking the cartesian product of
+	 *      the passed collections.
+	 */
+	function combinePermutations(firstGroup, secondGroup) {
+		const fgEntries = Object.entries(firstGroup);
+		if (fgEntries.length === 0) {
+			return secondGroup;
+		}
+
+		const sgEntries = Object.entries(secondGroup);
+		if (secondGroup.length === 0) {
+			return firstGroup;
+		}
+
+		const combined = {};
+		for (const [fgPermutation, fgCount] of fgEntries) {
+			for (const [sgPermutation, sgCount] of sgEntries) {
+				const newPermutation = mergeSymbolsString(fgPermutation, sgPermutation);
+
+				combined[newPermutation] = fgCount * sgCount + (combined[newPermutation] ?? 0);
+			}
+		}
+
+		return combined;
+	}
+
+	return {
+		forPool: forMixedPool,
+	};
+})();
+
+/**
+ * An object containing all the possible criteria that can be used.
+ * @type Record<string, (evaluation: Map<GenesysSymbol, number>) => boolean>
+ */
+const Criteria = {
+	SUCCESS: (evaluation) => {
+		return evaluation.get(Symbols.Success) > 0;
+	},
+};
+
+/**
+ * This function takes in a string representation of a collection of symbols and returns it as a dictionary.
+ * @param {string} symbolsString - A string that represents a collection of symbols.
+ * @returns {Map<GenesysSymbol, number>} A dictionary of the symbols present on the provided string.
+ */
+function getAndGroupSymbols(symbolsString) {
+	const symbols = new Map();
+	const matchedSymbols = [...symbolsString.matchAll(/(\d+)(\w)/g)];
+
+	for (const [, amount, denomination] of matchedSymbols) {
+		symbols.set(SymbolFromDenomination.get(denomination), parseInt(amount, 10));
+	}
+
+	return symbols;
+}
+
+/**
+ * This function takes in two collections of different symbols and evaluate their interaction.
+ * @param {Map<GenesysSymbol, number>} symbols - A list of different symbol types and their amount.
+ * @param {Map<GenesysSymbol, number>} extraSymbols - An additional list of symbols and their amount.
+ * @returns {Map<GenesysSymbol, number>} A dictionary of symbols and their total amount after taking into account
+ *      any interactions between them.
+ */
+function evaluateSymbols(symbols, extraSymbols) {
+	const evaluation = new Map();
+
+	for (const [symbol] of extraSymbols) {
+		let total = 0;
+
+		total += extraSymbols.get(symbol) ?? 0;
+		total -= extraSymbols.get(symbol.opposes) ?? 0;
+		total += extraSymbols.get(symbol.alsoIn) ?? 0;
+		total -= extraSymbols.get(symbol.opposes?.alsoIn) ?? 0;
+
+		total += symbols.get(symbol) ?? 0;
+		total -= symbols.get(symbol.opposes) ?? 0;
+		total += symbols.get(symbol.alsoIn) ?? 0;
+		total -= symbols.get(symbol.opposes?.alsoIn) ?? 0;
+
+		evaluation.set(symbol, total);
+	}
+
+	return evaluation;
+}
+
+/**
+ * This function calculates the total number of permutations possible for a given dice pool.
+ * @param {Map<GenesysDie, number>} dicePool - A pool of dice with their types and amount.
+ * @returns {number} The total number of possible permutations.
+ */
+function calculateTotalPermutations(dicePool) {
+	let totalPermutations = 1;
+	for (const [dice, amount] of dicePool) {
+		totalPermutations *= Math.pow(dice.faces.length, amount);
+	}
+
+	return totalPermutations;
+}
+
+/**
+ * This function calculates the chance of meeting the provided criteria given the provided dice pool.
+ * @param {Map<GenesysDie, number} dicePool - A pool of dice with their types and amount.
+ * @param {Map<GenesysSymbol, number} extraSymbols - A collection of extra symbols to add to the result.
+ * @param {(evaluation: Map<GenesysSymbol, number>) => boolean} criteria - A function that analyzes a
+ *      permutation and determines if it meets a specific criteria.
+ * @returns {number} The chance (as a ratio) of a dice pool to meet the provided criteria.
+ */
+function calculateChanceOf(dicePool, extraSymbols, criteria) {
+	const totalPermutations = calculateTotalPermutations(dicePool);
+
+	// If there is only 1 permutation then there are no dice on the pool. Simply evaluate any
+	// extra symbols.
+	if (totalPermutations === 1) {
+		const evaluation = evaluateSymbols(new Map(), extraSymbols);
+		return criteria(evaluation) ? 1 : 0;
+	}
+
+	const permutations = Permutations.forPool(dicePool);
+	let meetCriteria = 0;
+
+	for (const [permutation, count] of Object.entries(permutations)) {
+		const symbols = getAndGroupSymbols(permutation);
+		const evaluation = evaluateSymbols(symbols, extraSymbols);
+
+		if (criteria(evaluation)) {
+			meetCriteria += count;
+		}
+	}
+
+	return meetCriteria / totalPermutations;
+}
+
+/**
+ * This object is a cache of all the permutations calculated for mixed dice pools.
+ * @type Record<string, number>
+ */
+const cacheForPool = {};
+
+/**
+ * This function proccessed the input and relays the data to the functions that calculate the chance of
+ * meeting the specified criteria.
+ * @param {Record<string, number>} dicePool - A pool of dice with their types and amount.
+ * @param {Record<string, number>} extraSymbols - A collection of extra symbols to add to the result.
+ * @param {string} criteriaType - The type of criteria to use when calculating the chance of achieving it.
+ * @returns {Promise<number>} The chance (as a ratio) of a dice pool to meet the specified criteria.
+ */
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -- This is used by the Dice Prompt.
+async function calculateChanceForDicePool({ dicePool, extraSymbols, criteriaType }) {
+	const processedDicePool = Object.values(Dice).reduce((accum, dice) => {
+		const targetDiceAmount = dicePool[dice.denomination];
+		if (targetDiceAmount > 0) {
+			accum.set(dice, targetDiceAmount);
+		}
+		return accum;
+	}, new Map());
+	const dicePoolAsString = constructKeyFromMixedPool(processedDicePool);
+
+	const processedExtraSymbols = Object.values(Symbols).reduce((accum, symbol) => {
+		accum.set(symbol, extraSymbols[symbol.denomination] ?? 0);
+		return accum;
+	}, new Map());
+	const extraSymbolsAsString = constructKeyFromMixedPool(processedExtraSymbols);
+
+	const chosenCriteria = Criteria[criteriaType] ? criteriaType : 'SUCCESS';
+	const requestKey = `${dicePoolAsString}|${extraSymbolsAsString}|${chosenCriteria}`;
+
+	if (cacheForPool[requestKey]) {
+		return cacheForPool[requestKey];
+	}
+
+	const chanceResult = calculateChanceOf(processedDicePool, processedExtraSymbols, Criteria[chosenCriteria]);
+	cacheForPool[requestKey] = chanceResult;
+	return chanceResult;
+}

--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -20,6 +20,7 @@ import { register as registerActors, AdversaryTypes } from '@/actor';
 import { register as registerEffects } from '@/effects';
 import { register as registerItems, CharacterCreationItemTypes, EquipmentItemTypes } from '@/item';
 import { register as registerVehiclesRerender } from '@/actor/data/VehicleDataModel';
+import { registerWorker } from '@/app/DicePrompt';
 
 import './scss/index.scss';
 
@@ -107,6 +108,7 @@ Hooks.once('ready', async () => {
 
 	readyConfigs();
 	registerVehiclesRerender();
+	registerWorker();
 });
 
 function constructOptGroup(select: HTMLSelectElement, groupLabel: string, optValues?: string[]): HTMLOptGroupElement {

--- a/src/app/DicePrompt.ts
+++ b/src/app/DicePrompt.ts
@@ -14,6 +14,8 @@ import VueDicePrompt from '@/vue/apps/DicePrompt.vue';
 import WeaponDataModel from '@/item/data/WeaponDataModel';
 import VueSheet from '@/vue/VueSheet';
 import { Characteristic } from '@/data/Characteristics';
+import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
+import { KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION } from '@/settings/user';
 
 export enum RollType {
 	Skill,
@@ -122,5 +124,18 @@ export default class DicePrompt extends VueSheet(Application) {
 			rollUnskilled: this.rollUnskilled,
 			rollData: this.rollData,
 		};
+	}
+}
+
+export const CALCULATE_CHANCE_WORKER_NAME = 'CalculateChance';
+
+export function registerWorker() {
+	if (game.workers.get) {
+		const setupWorker = game.settings.get(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION) as boolean;
+		if (setupWorker) {
+			game.workers.createWorker(CALCULATE_CHANCE_WORKER_NAME, {
+				scripts: ['../systems/genesys/scripts/calculate-chance-worker.js'],
+			});
+		}
 	}
 }

--- a/src/settings/user.ts
+++ b/src/settings/user.ts
@@ -12,9 +12,14 @@
 export const KEY_USE_MAGICAL_GIRL_SYMBOLS = 'useMagicalGirlSymbols';
 
 /**
+ * Wheter the user wants to calculate the chance to succeed by constructing the permutations on a Web Worker.
+ */
+export const KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION = 'dicePoolChanceToSucceedByPermutation';
+
+/**
  * Number of simulated rolls to do to calculate the dice pool success chance. A value of 0 disables the feature.
  */
-export const KEY_DICE_POOL_APPROXIMATION = 'dicePoolApproximation';
+export const KEY_CHANCE_TO_SUCCEED_BY_SIMULATION = 'dicePoolApproximation';
 
 export function register(namespace: string) {
 	game.settings.register(namespace, KEY_USE_MAGICAL_GIRL_SYMBOLS, {
@@ -27,9 +32,23 @@ export function register(namespace: string) {
 		requiresReload: true,
 	});
 
-	game.settings.register(namespace, KEY_DICE_POOL_APPROXIMATION, {
-		name: game.i18n.localize('Genesys.Settings.DicePoolApproximation'),
-		hint: game.i18n.localize('Genesys.Settings.DicePoolApproximationHint'),
+	// This setting is only available for FVTT v11+ because it depends on the changes made to the workers API
+	// introduced in that version.
+	if (game.workers.get) {
+		game.settings.register(namespace, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION, {
+			name: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedByPermutation'),
+			hint: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedByPermutationHint'),
+			scope: 'client',
+			config: true,
+			default: false,
+			type: Boolean,
+			requiresReload: true,
+		});
+	}
+
+	game.settings.register(namespace, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION, {
+		name: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedBySimulation'),
+		hint: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedBySimulationHint'),
 		scope: 'client',
 		config: true,
 		default: 0,

--- a/types/foundry/client/collections/world-collection/worker-manager.d.ts
+++ b/types/foundry/client/collections/world-collection/worker-manager.d.ts
@@ -1,0 +1,7 @@
+/**
+ * The Collection of Web Workers which exist within the active World.
+ * This Collection is accessible within the Game object as game.workers.
+ */
+declare class WorkerManager extends Map<string, AsyncWorker> {
+	createWorker(name: string, config?: AsyncWorkerOptions): AsyncWorker;
+}

--- a/types/foundry/client/core/async-worker.d.ts
+++ b/types/foundry/client/core/async-worker.d.ts
@@ -1,0 +1,14 @@
+export {};
+
+declare global {
+	interface AsyncWorkerOptions {
+		debug: boolean;
+		loadPrimitives: boolean;
+		scripts: string[];
+	}
+
+	class AsyncWorker extends Worker {
+		constructor(name: string, config?: AsyncWorkerOptions);
+		executeFunction(functionName: string, args: any[], transfer: any[]): Promise<unknown>;
+	}
+}

--- a/types/foundry/client/game.d.ts
+++ b/types/foundry/client/game.d.ts
@@ -151,6 +151,8 @@ declare global {
 		tables: RollTables;
 		users: Users<TUser>;
 
+		workers: WorkerManager;
+
 		constructor(view: string, worldData: {}, sessionId: string, socket: io.Socket);
 
 		/** Returns the current version of the Release, usable for comparisons using isNewerVersion */

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -47,8 +47,16 @@ Genesys:
     SkillForRepairingVehicleHitsHint: Name of the skill used when recovering from Critical Hits.
     UseMagicalGirlSymbols: Use Magical Girl Symbols by MilkMyth (Client-Only)
     UseMagicalGirlSymbolsHint: Swap the Genesys symbol set for MilkMyth's Magical Girls symbol set. This will not affect other users.
-    DicePoolApproximation: Dice Pool Approximation
-    DicePoolApproximationHint: The number of simulated rolls to run in order to approximate the chance to succeed. Be mindful when increasing this number since it will have a direct impact on Foundry's performance; a good number to start is 100. If a value of 0 is provided this feature is disabled.
+    DicePoolChanceToSucceedByPermutation: Calculate the Chance to Succeed for Dice Pools
+    DicePoolChanceToSucceedByPermutationHint: >-
+      If enabled this will spawn a Web Worker that calculates the exact chance to succeed.
+      However, if the dice pool uses a super characteristic the calculated value is lower than the true value beccause it assumes that the pool didn't explode.
+      For dice pools that use super characteristics you can get a more accurate value by using simulations.
+    DicePoolChanceToSucceedBySimulation: Approximate the Chance to Succeed for Dice Pools
+    DicePoolChanceToSucceedBySimulationHint: >-
+      The number of simulated rolls to run in order to approximate the chance to succeed.
+      Be mindful when increasing this number since it will have a direct impact on Foundry's performance; a good number to start is 100. If a value of 0 is provided this feature is disabled.
+      This setting is ignored if the chance is already being calculated some other way.
     SuperCharacteristics: Super-Characteristics
     SuperCharacteristicsHint: Allows marking characteristics as being 'super' during character creation, per the Super-Characteristics optional rule (Core Rulebook, p.251).
 
@@ -140,8 +148,9 @@ Genesys:
     Title: Dice Pool
     Roll: Roll!
     Hint: Use the dice box on the right to add, upgrade, and downgrade. Click dice in the pool to remove them!
-    Approximation: 'Chance to Succeed:'
-    ApproximationDisclaimer: The displayed probability is an approximation that uses the Monte Carlo method.
+    ChanceToSucceed: 'Chance to Succeed:'
+    ChanceToSucceedByPermutationDisclaimer: The displayed probability is exact unless the dice pool includes a super characteristic.
+    ChanceToSucceedBySimulationDisclaimer: The displayed probability is an approximation that uses the Monte Carlo method.
 
   # Experience Journal Labels
   XPJournal:


### PR DESCRIPTION
A while back I published a PR that made it possible to see the chance to succeed of a dice pool by means of simulation (#77). In the comments 'thirionlogan' pointed out at an alternative way of calculating the chance to succeed. I have since gone over the code he referenced and have created my own version. Basically the new method constructs all the possible permutations of rolling the dice pool, aggregating those that are similar. It then goes over every permutation and checks which meets a specific criteria and compares those to the total amount. This way we can get an exact value for the chance to succeed.

There are a few caveats:
- The new method is inaccurate for pools with exploding dice, like those that use a super characteristic. For those cases the simulation could yield more accurate results.
- Because the new method can be a little resource intensive I've delegated the work to a Web Worker. In the future I'll do the same for the "simulations" method.
- The way I'm interacting with the `game.workers` API limits this feature to FVTT v11+

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/f0aebb38-443c-49ce-b506-0c7c3161835a)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/6fcfe9ab-b649-424e-8b99-f95fecf55428)