### PR TITLE
Vehicle improvements

### DIFF
--- a/public/templates/sheets/effect-config.hbs
+++ b/public/templates/sheets/effect-config.hbs
@@ -148,6 +148,8 @@
                                     {{!-- Vehicle Secondary Stats --}}
                                     <option value="system.hullTrauma.max">&#x1F697; {{localize 'Genesys.Labels.HullTraumaThreshold'}}</option>
                                     <option value="system.systemStrain.max">&#x1F697; {{localize 'Genesys.Labels.SystemStrainThreshold'}}</option>
+                                    <option value="system.passengers.value">&#x1F697; {{localize 'Genesys.Labels.Passengers'}}</option>
+                                    <option value="system.passengers.threshold">&#x1F697; {{localize 'Genesys.Labels.PassengerCapacity'}}</option>
 
                                     {{!-- Shared Secondary Stats --}}
                                     <option value="system.encumbrance.value">&#x1F310; {{localize 'Genesys.Labels.Encumbrance'}}</option>

--- a/src/actor/sheets/VehicleSheet.ts
+++ b/src/actor/sheets/VehicleSheet.ts
@@ -86,7 +86,7 @@ export default class VehicleSheet extends VueSheet(GenesysActorSheet<VehicleData
 		}
 
 		const actor = (await fromUuid(data.uuid)) as GenesysActor;
-		if (!actor || !VehicleDataModel.RELEVANT_TYPES.DROP_ACTOR.includes(actor.type)) {
+		if (!actor || !VehicleDataModel.RELEVANT_TYPES.DROP_ACTOR.includes(actor.type) || !actor.isOwner) {
 			return false;
 		}
 		const actorId = actor.id;

--- a/src/vue/apps/DicePrompt.vue
+++ b/src/vue/apps/DicePrompt.vue
@@ -73,7 +73,7 @@ const availableSkills = computed<GenesysItem<SkillDataModel>[]>(() => toRaw(cont
 const canChangeCharacteristic = computed(() => !selectedSkill.value || (game.settings.get(SETTINGS_NAMESPACE, KEY_UNCOUPLE_SKILLS_FROM_CHARACTERISTICS) as boolean));
 
 const USE_CHANCE_TO_SUCCEED_BY_SIMULATION = Math.floor(game.settings.get(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION) as number);
-const USE_CHANCE_TO_SUCCEED_BY_PERMUTATION = game.settings.get(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION) as boolean;
+const USE_CHANCE_TO_SUCCEED_BY_PERMUTATION = game.workers.get && (game.settings.get(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION) as boolean);
 const USE_CHANCE_TO_SUCCEED = USE_CHANCE_TO_SUCCEED_BY_PERMUTATION || USE_CHANCE_TO_SUCCEED_BY_SIMULATION > 0;
 
 let currentDicePool: DicePool = {

--- a/src/vue/apps/SelectCharacterSkillPrompt.vue
+++ b/src/vue/apps/SelectCharacterSkillPrompt.vue
@@ -40,7 +40,9 @@ function submitSelection(event: Event) {
 		>
 			<img class="char-image" :src="characterSkillOption.actor.img" :alt="characterSkillOption.actor.name" draggable="false" />
 			<div class="char-name">{{ characterSkillOption.actor.name }}</div>
+
 			<div class="skill-name">{{ characterSkillOption.skill.name }}</div>
+			<div class="skill-rank">{{ characterSkillOption.skill.systemData.rank }}</div>
 			<SkillRanks
 				:skill-value="characterSkillOption.skill.systemData.rank"
 				:characteristic-value="(characterSkillOption.actor.systemData as _NonVehicleDataModel).characteristics[characterSkillOption.skill.systemData.characteristic]"
@@ -67,7 +69,7 @@ function submitSelection(event: Event) {
 .select-character-skill-prompt {
 	.char-skill-option {
 		display: grid;
-		grid-template-columns: 2rem 1fr auto auto;
+		grid-template-columns: 2rem 1fr auto auto auto;
 		gap: 0.3em;
 		align-items: center;
 		margin-bottom: 0.3rem;
@@ -88,6 +90,18 @@ function submitSelection(event: Event) {
 
 		.skill-name {
 			font-family: 'Roboto', sans-serif;
+		}
+
+		.skill-rank {
+			font-family: 'Roboto', sans-serif;
+			background: transparentize(white, 0.5);
+			border: 1px dashed black;
+			border-radius: 0.75rem;
+			text-align: center;
+			margin: 0.1em 0.1em 0.1em 0.2em;
+			min-width: 1.5rem;
+			height: 1.5rem;
+			font-size: 1rem;
 		}
 	}
 

--- a/src/vue/components/character/Characteristic.vue
+++ b/src/vue/components/character/Characteristic.vue
@@ -45,7 +45,7 @@ withDefaults(
 		/**
 		 * Value to display for the Characteristic.
 		 */
-		value: number;
+		value: number | string;
 	}>(),
 	{
 		canUpgrade: false,
@@ -94,7 +94,7 @@ const unmarkSuperCharacteristicLabel = game.i18n.localize('Genesys.Labels.Unmark
 		<div class="value">
 			<i v-if="allowSuperCharacteristics && isSuper" class="fas fa-star super-star"></i>
 
-			<input v-if="canEdit" type="number" :name="name" :value="value" min="0" />
+			<input v-if="canEdit" type="text" data-dtype="Number" :name="name" :value="value" />
 			<div v-else>{{ value }}</div>
 		</div>
 	</div>

--- a/src/vue/sheets/actor/VehicleSheet.vue
+++ b/src/vue/sheets/actor/VehicleSheet.vue
@@ -48,7 +48,7 @@ onBeforeUpdate(updateEffects);
 			<div class="stats-row">
 				<Characteristic label="Genesys.Labels.Silhouette" :value="system.silhouette" name="system.silhouette" can-edit />
 				<Characteristic label="Genesys.Labels.Speed" :value="system.speed" name="system.speed" can-edit />
-				<Characteristic label="Genesys.Labels.Handling" :value="system.handling" name="system.handling" can-edit />
+				<Characteristic label="Genesys.Labels.Handling" :value="`${system.handling >= 0 ? '+' : ''}${system.handling}`" name="system.handling" can-edit />
 
 				<div class="stats-column">
 					<CombatStat label="Genesys.Labels.Defense" name="system.defense" :value="system.defense" edit-primary />

--- a/src/vue/sheets/actor/vehicle/CombatTab.vue
+++ b/src/vue/sheets/actor/vehicle/CombatTab.vue
@@ -75,6 +75,11 @@ async function pickAttackerAndRollAttack(weapon: GenesysItem<VehicleWeaponDataMo
 		return;
 	}
 
+	if (!selectAttacker.actor.isOwner) {
+		ui.notifications.warn(game.i18n.localize('Genesys.Notifications.CannotSelectActor'));
+		return;
+	}
+
 	await DicePrompt.promptForRoll(selectAttacker.actor, selectAttacker.skill.id, {
 		rollType: RollType.Attack,
 		rollData: { weapon },
@@ -101,6 +106,11 @@ async function repairHit(criticalHit: GenesysItem<InjuryDataModel>) {
 
 	const selectRepairer = await SelectCharacterSkillPrompt.promptFromCharactersList(potentialRepairer);
 	if (!selectRepairer) {
+		return;
+	}
+
+	if (!selectRepairer.actor.isOwner) {
+		ui.notifications.warn(game.i18n.localize('Genesys.Notifications.CannotSelectActor'));
 		return;
 	}
 

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -77,6 +77,7 @@ async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDa
 									<span>{{ skill.name }} (<Localized :label="`Genesys.CharacteristicAbbr.${skill.systemData.characteristic.capitalize()}`" />)</span>
 								</a>
 
+								<span class="skill-rank">{{ skill.systemData.rank }}</span>
 								<SkillRanks :skill-value="skill.systemData.rank" :characteristic-value="(details.actor.systemData as _NonVehicleDataModel).characteristics[skill.systemData.characteristic]" />
 							</div>
 						</div>
@@ -151,12 +152,16 @@ async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDa
 					.member-skill {
 						width: 100%;
 						display: grid;
-						grid-template-columns: /* image */ 1.5rem /* name */ 1fr /* Dice Preview */ 80px;
+						grid-template-columns: /* image */ 1.5rem /* name */ 1fr /* rank */ auto /* Dice Preview */ 80px;
 						align-items: center;
 						gap: 0.25rem;
 
 						border-bottom: 1px dashed black;
 						padding: 1px;
+
+						&:last-of-type {
+							border-bottom: none;
+						}
 
 						& > * {
 							padding: 0.2em;
@@ -177,8 +182,14 @@ async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDa
 							}
 						}
 
-						&:last-of-type {
-							border-bottom: none;
+						.skill-rank {
+							background: transparentize(white, 0.5);
+							border: 1px dashed black;
+							border-radius: 0.75rem;
+							text-align: center;
+							margin: 0.1em 0.1em 0.1em 0.2em;
+							min-width: 1.5rem;
+							height: 1.5rem;
 						}
 					}
 				}

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -54,6 +54,10 @@ async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDa
 		await DicePrompt.promptForRoll(actor, skill.id);
 	}
 }
+
+async function openActorSheet(actor: GenesysActor) {
+	await actor.sheet.render(true);
+}
 </script>
 
 <template>
@@ -62,7 +66,7 @@ async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDa
 			<section v-for="[memberId, details] in dataGroupedByMember" :key="memberId">
 				<div class="member-details">
 					<img class="member-image" :src="details.actor.img" :alt="details.actor.name" draggable="false" />
-					<div class="member-name">{{ details.actor.name }}</div>
+					<a class="member-name" @click="openActorSheet(details.actor)">{{ details.actor.name }}</a>
 					<div class="member-roles"><Localized label="Genesys.Labels.Roles" />: {{ details.roles.join(', ') }}</div>
 
 					<div class="member-skills" v-if="details.skills.size > 0">

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -180,6 +180,7 @@ Genesys:
     SelectOneTokenForAction: You need to selected a single token to perform this action.
     TokenIsNotCombatant: The selected token is not participating on the current combat.
     CannotClaimOppositeSlot: You can't claim this initiative slot with {name} - it's on the wrong side!
+    CannotSelectActor: You do not have sufficient permission to select this Actor.
 
   # Story Points
   StoryPoints:


### PR DESCRIPTION
- Adds a plus sign to positive values (and for 0) when displaying the "Handling" characteristic
- Limits the actors that can be dropped into a vehicle to only those you own.
- Display skill ranks on the "Skills" tan and the "Character Skill Selection" prompt.
- Open a character sheet when clicking on their name in the "Skills" tab.
- When selecting a skill from the "Character Skill Selection" prompt it now throws a warning when selecting an actor that you don't own (previously it was letting you roll for anyone).
- Fixed a bug on FVTTv10 when opening the Dice Prompt (related to the alternate method to calculate the chance to succeed).
- Adds the option to modify a vehicle's passenger quantity and capacity by using after effects.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/a3567844-34b9-4ba2-b230-0fb98916c41c)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/24411041-3ba7-41ad-8ca0-63d1db70f4d9)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/1a6e7e85-03e1-4c7f-818f-dd556ec33e80)