### PR TITLE
Bugfix: Scope the character and vehicle styles

### DIFF
--- a/src/vue/sheets/actor/character/CombatTab.vue
+++ b/src/vue/sheets/actor/character/CombatTab.vue
@@ -172,7 +172,7 @@ function damageForWeapon(weapon: GenesysItem<WeaponDataModel>) {
 	</section>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @use '@scss/vars/colors.scss';
 
 .tab-combat {

--- a/src/vue/sheets/actor/character/JournalTab.vue
+++ b/src/vue/sheets/actor/character/JournalTab.vue
@@ -170,7 +170,7 @@ async function addXPJournalEntry() {
 	</section>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @use '@scss/mixins/reset.scss';
 @use '@scss/vars/colors.scss';
 
@@ -187,8 +187,10 @@ async function addXPJournalEntry() {
 		padding: 0.75em;
 
 		&.experience {
-			background: none;
 			grid-column: 1 / span all;
+			display: grid;
+			grid-template-columns: auto 1fr auto;
+			width: 100%;
 		}
 
 		& > .header {
@@ -406,13 +408,5 @@ async function addXPJournalEntry() {
 			background: transparentize(colors.$light-blue, 0.8);
 		}
 	}
-}
-
-.experience {
-	display: grid;
-	grid-template-columns: auto 1fr auto;
-	width: 100%;
-	padding-top: 0;
-	padding-bottom: 0;
 }
 </style>

--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -311,6 +311,9 @@ async function deleteSkill(skill: GenesysItem<SkillDataModel>) {
 	.experience {
 		grid-column: 1 / span all;
 		padding: 0.5em;
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		width: 100%;
 	}
 
 	.skills-row {

--- a/src/vue/sheets/actor/vehicle/CombatTab.vue
+++ b/src/vue/sheets/actor/vehicle/CombatTab.vue
@@ -199,7 +199,7 @@ async function repairHit(criticalHit: GenesysItem<InjuryDataModel>) {
 	</section>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @use '@scss/vars/colors.scss';
 
 .tab-combat {

--- a/src/vue/sheets/actor/vehicle/CrewTab.vue
+++ b/src/vue/sheets/actor/vehicle/CrewTab.vue
@@ -233,7 +233,7 @@ function dragEnd() {
 	</section>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @use '@scss/mixins/reset.scss';
 @use '@scss/vars/colors.scss';
 

--- a/src/vue/sheets/actor/vehicle/DetailsTab.vue
+++ b/src/vue/sheets/actor/vehicle/DetailsTab.vue
@@ -62,7 +62,7 @@ const system = computed(() => toRaw(context.data.actor).systemData);
 	</section>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @use '@scss/mixins/reset.scss';
 @use '@scss/vars/colors.scss';
 

--- a/src/vue/sheets/actor/vehicle/InventoryTab.vue
+++ b/src/vue/sheets/actor/vehicle/InventoryTab.vue
@@ -212,7 +212,7 @@ async function drop(event: DragEvent) {
 	</section>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @use '@scss/mixins/reset.scss';
 @use '@scss/vars/colors.scss';
 


### PR DESCRIPTION
The vehicle's Combat tab has un-scopped styling being applied to the character's Combat tab. This result in an extra empty column showing up:
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/4211fd4a-8bf9-431e-89fd-5908a3077e51)

This fixes the problem and additionally scopes all the styling for both sheet's tabs.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/7759bee4-ba78-422d-b8af-1f19c9f8c753)