### PR TITLE
Access the dice prompt directly from the chat

### DIFF
--- a/src/actor/GenesysActorSheet.ts
+++ b/src/actor/GenesysActorSheet.ts
@@ -42,12 +42,7 @@ export default class GenesysActorSheet<ActorDataModel extends foundry.abstract.D
 				const skillName = <string>target.data('skill-check');
 				const difficulty = parseInt(target.data('difficulty'));
 
-				// Does this actor possess the skill in question?
-				const matchingSkill = <GenesysItem>this.actor.items.find((i) => i.name.toLowerCase() === skillName.toLowerCase());
-
-				const skillId = matchingSkill ? matchingSkill.id : '-';
-
-				await DicePrompt.promptForRoll(this.actor, skillId, { startingDifficulty: difficulty });
+				await DicePrompt.promptForRoll(this.actor, skillName, { difficulty });
 			});
 		}, 250);
 	}

--- a/src/actor/data/CharacterDataModel.ts
+++ b/src/actor/data/CharacterDataModel.ts
@@ -12,10 +12,9 @@ import IHasPreCreate from '@/data/IHasPreCreate';
 import GenesysItem from '@/item/GenesysItem';
 import ArmorDataModel from '@/item/data/ArmorDataModel';
 import EquipmentDataModel, { EquipmentState } from '@/item/data/EquipmentDataModel';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_SKILLS_COMPENDIUM, DEFAULT_SKILLS_COMPENDIUM } from '@/settings/campaign';
 import { Characteristic, CharacteristicsContainer } from '@/data/Characteristics';
 import { CombatPool, Defense } from '@/data/Actors';
+import { DEFAULT_SKILLS_COMPENDIUM } from '@/config';
 
 export const EQUIPMENT_TYPES = ['armor', 'consumable', 'container', 'gear', 'weapon'];
 
@@ -220,7 +219,7 @@ export default abstract class CharacterDataModel extends foundry.abstract.DataMo
 			return;
 		}
 
-		let skillsCompendiumName = <string>game.settings.get(SETTINGS_NAMESPACE, KEY_SKILLS_COMPENDIUM);
+		let skillsCompendiumName = CONFIG.genesys.skillsCompendium;
 
 		// Validate the setting is actually set.
 		if (skillsCompendiumName.length === 0) {

--- a/src/combat/GenesysCombat.ts
+++ b/src/combat/GenesysCombat.ts
@@ -146,12 +146,11 @@ export default class GenesysCombat extends Combat {
 
 			// Initiative roll result
 			let skillName = combatant.initiativeSkill?.skillName ?? this.initiativeSkills[0]?.skillName ?? 'Unskilled';
-			const skillId = combatant.actor.items.find((i) => i.type === 'skill' && i.name.toLowerCase() === skillName.toLowerCase())?.id ?? '-';
 			let roll: Roll | undefined;
 
 			if (prompt) {
 				try {
-					const promptedRoll = await DicePrompt.promptForInitiative(combatant.actor, skillId, { startingDifficulty: 0 });
+					const promptedRoll = await DicePrompt.promptForInitiative(combatant.actor, skillName, { difficulty: 0 });
 
 					roll = promptedRoll.roll;
 					skillName = promptedRoll.skillName;

--- a/src/combat/GenesysCombatTracker.ts
+++ b/src/combat/GenesysCombatTracker.ts
@@ -9,8 +9,6 @@
 import GenesysCombat, { InitiativeSkill } from '@/combat/GenesysCombat';
 import GenesysCombatant from '@/combat/GenesysCombatant';
 import SkillDataModel from '@/item/data/SkillDataModel';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_SKILLS_COMPENDIUM } from '@/settings/campaign';
 import GenesysItem from '@/item/GenesysItem';
 import { Characteristic } from '@/data/Characteristics';
 
@@ -23,8 +21,7 @@ export default class GenesysCombatTracker extends CombatTracker<GenesysCombat> {
 
 	async initiativeSkills() {
 		if (!this.#initiativeSkills || this.#initiativeSkills.length === 0) {
-			const compendiumId = game.settings.get(SETTINGS_NAMESPACE, KEY_SKILLS_COMPENDIUM) as string;
-			const compendium = game.packs.get(compendiumId);
+			const compendium = game.packs.get(CONFIG.genesys.skillsCompendium);
 
 			if (!compendium) {
 				return [{ skillName: 'Unskilled', skillChar: Characteristic.Brawn }];

--- a/src/combat/GenesysCombatant.ts
+++ b/src/combat/GenesysCombatant.ts
@@ -15,8 +15,6 @@ import SkillDataModel from '@/item/data/SkillDataModel';
 import MinionDataModel from '@/actor/data/MinionDataModel';
 import { Characteristic } from '@/data/Characteristics';
 import GenesysRoller from '@/dice/GenesysRoller';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_SUPER_CHARACTERISTICS } from '@/settings/campaign';
 
 export default class GenesysCombatant extends Combatant<GenesysCombat, GenesysActor> {
 	initiativeSkill?: InitiativeSkill;
@@ -59,8 +57,7 @@ export default class GenesysCombatant extends Combatant<GenesysCombat, GenesysAc
 		const yellow = Math.min(characteristicValue, skillValue);
 		const green = Math.max(characteristicValue, skillValue) - yellow;
 
-		const allowSuperCharacteristics = game.settings.get(SETTINGS_NAMESPACE, KEY_SUPER_CHARACTERISTICS) as boolean;
-		const useSuperCharacteristic = allowSuperCharacteristics && system.superCharacteristics.has(characteristic);
+		const useSuperCharacteristic = CONFIG.genesys.useSuperCharacteristics && system.superCharacteristics.has(characteristic);
 
 		return new Roll(`${yellow}dP${useSuperCharacteristic ? 'X' : ''}+${green}dA`);
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,13 +7,65 @@
  */
 
 import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_USE_MAGICAL_GIRL_SYMBOLS } from '@/settings/user';
+import {
+	KEY_CAREER_SKILL_RANKS,
+	KEY_MONEY_NAME,
+	KEY_SHOW_DAMAGE_ON_FAILURE,
+	KEY_SKILLS_COMPENDIUM,
+	KEY_SKILL_FOR_INJURIES,
+	KEY_SKILL_FOR_REPAIRING_VEHICLE_HITS,
+	KEY_SUPER_CHARACTERISTICS,
+	KEY_UNCOUPLE_SKILLS_FROM_CHARACTERISTICS,
+} from '@/settings/campaign';
+import { KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION, KEY_USE_MAGICAL_GIRL_SYMBOLS } from '@/settings/user';
+
+/**
+ * Default skills compendium to use if the setting is misconfigured.
+ */
+export const DEFAULT_SKILLS_COMPENDIUM = 'genesys.crb-skills';
 
 export const GENESYS_CONFIG = {
-	/**
-	 * Whether to use the Magical Girl symbols where possible in the system.
-	 */
-	useMagicalGirlSymbols: true,
+	/** World Settings **/
+
+	// Default skills compendium to use if the setting is misconfigured.
+	skillsCompendium: DEFAULT_SKILLS_COMPENDIUM,
+
+	// The name of the skill to use for healing Critical Injuries.
+	skillForHealingInjury: 'Resilience',
+
+	// The name of the skill to use for repairing Critical Hits.
+	skillForRepairingHit: 'Mechanics',
+
+	// Name of the currency used for the setting.
+	currencyName: 'Money',
+
+	// Number of free skill ranks characters gain from careers.
+	freeCareerSkillRanks: 4,
+
+	// Whether to allow use of the Uncoupling Skills from Characteristics alternate rule.
+	uncoupleSkillsFromCharacteristics: false,
+
+	// Whether to show Damage, Critical, and Qualities on attack roll chat cards even when the roll was a failure.
+	showAttackDetailsOnFailure: false,
+
+	// Whether to use the optional rule for super-characteristics.
+	useSuperCharacteristics: false,
+
+	/** User Settings **/
+
+	// Whether to use the Magical Girl symbols where possible in the system.
+	useMagicalGirlSymbols: false,
+
+	// Wheter to show the chance to succeed of a dice pool by constructing permutations.
+	showChanceToSucceedFromPermutations: false,
+
+	showChanceToSucceedFromSimulations: {
+		// Wheter to show the chance to succeed of a dice pool by performing simulations.
+		enabled: false,
+
+		// Number of simulated rolls to do to calculate the dice pool success chance.
+		amountOfRolls: 0,
+	},
 };
 
 /**
@@ -24,8 +76,29 @@ export function register() {
 }
 
 /**
- * Called on 'ready' to initialize values that rely on items established in init.
+ * Called on 'ready' to initialize the values of the Genesys CONFIG with the settings established in init.
  */
 export function ready() {
-	CONFIG.genesys.useMagicalGirlSymbols = game.settings.get(SETTINGS_NAMESPACE, KEY_USE_MAGICAL_GIRL_SYMBOLS) as boolean;
+	/** World Settings **/
+
+	CONFIG.genesys.skillsCompendium = (game.settings.get(SETTINGS_NAMESPACE, KEY_SKILLS_COMPENDIUM) as string) ?? '';
+	CONFIG.genesys.skillForHealingInjury = (game.settings.get(SETTINGS_NAMESPACE, KEY_SKILL_FOR_INJURIES) as string) ?? '';
+	CONFIG.genesys.skillForRepairingHit = (game.settings.get(SETTINGS_NAMESPACE, KEY_SKILL_FOR_REPAIRING_VEHICLE_HITS) as string) ?? '';
+	CONFIG.genesys.currencyName = (game.settings.get(SETTINGS_NAMESPACE, KEY_MONEY_NAME) as string) ?? '';
+	CONFIG.genesys.freeCareerSkillRanks = Math.floor(Math.abs((game.settings.get(SETTINGS_NAMESPACE, KEY_CAREER_SKILL_RANKS) as number) ?? 0));
+	CONFIG.genesys.uncoupleSkillsFromCharacteristics = (game.settings.get(SETTINGS_NAMESPACE, KEY_UNCOUPLE_SKILLS_FROM_CHARACTERISTICS) as boolean) ?? false;
+	CONFIG.genesys.showAttackDetailsOnFailure = (game.settings.get(SETTINGS_NAMESPACE, KEY_SHOW_DAMAGE_ON_FAILURE) as boolean) ?? false;
+	CONFIG.genesys.useSuperCharacteristics = (game.settings.get(SETTINGS_NAMESPACE, KEY_SUPER_CHARACTERISTICS) as boolean) ?? false;
+
+	/** User Settings **/
+
+	CONFIG.genesys.useMagicalGirlSymbols = (game.settings.get(SETTINGS_NAMESPACE, KEY_USE_MAGICAL_GIRL_SYMBOLS) as boolean) ?? false;
+
+	if (game.workers.get) {
+		CONFIG.genesys.showChanceToSucceedFromPermutations = (game.settings.get(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION) as boolean) ?? false;
+	}
+
+	const amountOfRolls = Math.floor(Math.abs((game.settings.get(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION) as number) ?? 0));
+	CONFIG.genesys.showChanceToSucceedFromSimulations.enabled = amountOfRolls > 0;
+	CONFIG.genesys.showChanceToSucceedFromSimulations.amountOfRolls = amountOfRolls;
 }

--- a/src/dice/GenesysRoller.ts
+++ b/src/dice/GenesysRoller.ts
@@ -12,8 +12,6 @@ import { Characteristic } from '@/data/Characteristics';
 import GenesysItem from '@/item/GenesysItem';
 import WeaponDataModel from '@/item/data/WeaponDataModel';
 import VehicleWeaponDataModel from '@/item/data/VehicleWeaponDataModel';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_SHOW_DAMAGE_ON_FAILURE } from '@/settings/campaign';
 
 export type GenesysRollResults = {
 	/**
@@ -90,6 +88,8 @@ export default class GenesysRoller {
 				description = game.i18n.format('Genesys.Rolls.Description.Characteristic', {
 					characteristic: game.i18n.localize(`Genesys.Characteristics.${characteristic.capitalize()}`),
 				});
+			} else if (!actor) {
+				description = game.i18n.localize('Genesys.Rolls.Description.Simple');
 			}
 		} else if (actor) {
 			if (characteristic) {
@@ -113,7 +113,6 @@ export default class GenesysRoller {
 		const chatData = {
 			user: game.user.id,
 			speaker: { actor: actor?.id },
-			rollMode: game.settings.get('core', 'rollMode'),
 			content: html,
 			type: CONST.CHAT_MESSAGE_TYPES.ROLL,
 			roll,
@@ -192,7 +191,7 @@ export default class GenesysRoller {
 			critical: weapon.systemData.critical,
 			// tbh I can't be assed to implement another Handlebars helper for array length so let's just do undefined. <.<
 			qualities: weapon.systemData.qualities.length === 0 ? undefined : attackQualities,
-			showDamageOnFailure: game.settings.get(SETTINGS_NAMESPACE, KEY_SHOW_DAMAGE_ON_FAILURE) as boolean,
+			showDamageOnFailure: CONFIG.genesys.showAttackDetailsOnFailure,
 		};
 		const html = await renderTemplate('systems/genesys/templates/chat/rolls/attack.hbs', rollData);
 

--- a/src/dice/index.ts
+++ b/src/dice/index.ts
@@ -16,13 +16,23 @@ import ChallengeDie from '@/dice/types/ChallengeDie';
 import './diceSoNice';
 
 /**
+ * An object used to get general details of each dice type.
+ */
+export const DieType = {
+	Proficiency: ProficiencyDie,
+	Ability: AbilityDie,
+	Boost: BoostDie,
+
+	Challenge: ChallengeDie,
+	Difficulty: DifficultyDie,
+	Setback: SetbackDie,
+};
+
+/**
  * Registers custom dice types.
  */
 export function register() {
-	CONFIG.Dice.terms[BoostDie.DENOMINATION] = BoostDie;
-	CONFIG.Dice.terms[AbilityDie.DENOMINATION] = AbilityDie;
-	CONFIG.Dice.terms[ProficiencyDie.DENOMINATION] = ProficiencyDie;
-	CONFIG.Dice.terms[SetbackDie.DENOMINATION] = SetbackDie;
-	CONFIG.Dice.terms[DifficultyDie.DENOMINATION] = DifficultyDie;
-	CONFIG.Dice.terms[ChallengeDie.DENOMINATION] = ChallengeDie;
+	Object.values(DieType).forEach((dieType) => {
+		CONFIG.Dice.terms[dieType.DENOMINATION] = dieType;
+	});
 }

--- a/src/dice/types/AbilityDie.ts
+++ b/src/dice/types/AbilityDie.ts
@@ -6,12 +6,15 @@
  * @file Definition for the Ability die.
  */
 
-import GenesysDie from '@/dice/types/GenesysDie';
+import GenesysDie, { DieCategory } from '@/dice/types/GenesysDie';
 
 /**
  * Ability (green) Die
  */
 export default class AbilityDie extends GenesysDie {
 	static override DENOMINATION = 'a';
+	static override GLYPH = 'A';
+	static override FORMULA = 'da';
+	static override CATEGORY = 'positive' as DieCategory;
 	static override FACES = [' ', 's', 's', 'ss', 'a', 'a', 'sa', 'aa'];
 }

--- a/src/dice/types/BoostDie.ts
+++ b/src/dice/types/BoostDie.ts
@@ -6,12 +6,15 @@
  * @file Definition for the Boost die.
  */
 
-import GenesysDie from '@/dice/types/GenesysDie';
+import GenesysDie, { DieCategory } from '@/dice/types/GenesysDie';
 
 /**
  * Boost (blue) Die
  */
 export default class BoostDie extends GenesysDie {
 	static override DENOMINATION = 'b';
+	static override GLYPH = 'B';
+	static override FORMULA = 'db';
+	static override CATEGORY = 'positive' as DieCategory;
 	static override FACES = [' ', ' ', 's', 'sa', 'aa', 'a'];
 }

--- a/src/dice/types/ChallengeDie.ts
+++ b/src/dice/types/ChallengeDie.ts
@@ -6,12 +6,15 @@
  * @file Definition for the Challenge die.
  */
 
-import GenesysDie from '@/dice/types/GenesysDie';
+import GenesysDie, { DieCategory } from '@/dice/types/GenesysDie';
 
 /**
  * Challenge (red) Die
  */
 export default class ChallengeDie extends GenesysDie {
 	static override DENOMINATION = 'c';
+	static override GLYPH = 'C';
+	static override FORMULA = 'dc';
+	static override CATEGORY = 'negative' as DieCategory;
 	static override FACES = [' ', 'f', 'f', 'ff', 'ff', 'h', 'h', 'fh', 'fh', 'hh', 'hh', 'd'];
 }

--- a/src/dice/types/DifficultyDie.ts
+++ b/src/dice/types/DifficultyDie.ts
@@ -6,12 +6,15 @@
  * @file Definition for the Difficulty die.
  */
 
-import GenesysDie from '@/dice/types/GenesysDie';
+import GenesysDie, { DieCategory } from '@/dice/types/GenesysDie';
 
 /**
  * Difficulty (purple) Die
  */
 export default class DifficultyDie extends GenesysDie {
 	static override DENOMINATION = 'i';
+	static override GLYPH = 'D';
+	static override FORMULA = 'di';
+	static override CATEGORY = 'negative' as DieCategory;
 	static override FACES = [' ', 'f', 'ff', 'h', 'h', 'h', 'hh', 'fh'];
 }

--- a/src/dice/types/GenesysDie.ts
+++ b/src/dice/types/GenesysDie.ts
@@ -6,10 +6,27 @@
  * @file Root type of all the custom Die types in the Genesys system.
  */
 
+export type DieCategory = 'positive' | 'negative';
+
 /**
  * Base type of all custom Genesys dice.
  */
 export default abstract class GenesysDie extends Die {
+	/**
+	 * The text glyph used to symbolize this die.
+	 */
+	static readonly GLYPH: string = '';
+
+	/**
+	 * The format used when adding this die to a roll.
+	 */
+	static readonly FORMULA: string = '';
+
+	/**
+	 * The category to which the die belongs.
+	 */
+	static readonly CATEGORY: DieCategory;
+
 	/**
 	 * Faces of this die type.
 	 */

--- a/src/dice/types/ProficiencyDie.ts
+++ b/src/dice/types/ProficiencyDie.ts
@@ -6,12 +6,15 @@
  * @file Definition for the Proficiency die.
  */
 
-import GenesysDie from '@/dice/types/GenesysDie';
+import GenesysDie, { DieCategory } from '@/dice/types/GenesysDie';
 
 /**
  * Proficiency (yellow) Die
  */
 export default class ProficiencyDie extends GenesysDie {
 	static override DENOMINATION = 'p';
+	static override GLYPH = 'P';
+	static override FORMULA = 'dp';
+	static override CATEGORY = 'positive' as DieCategory;
 	static override FACES = [' ', 's', 's', 'ss', 'ss', 'a', 'sa', 'sa', 'sa', 'aa', 'aa', 't'];
 }

--- a/src/dice/types/SetbackDie.ts
+++ b/src/dice/types/SetbackDie.ts
@@ -6,12 +6,15 @@
  * @file Definition for the Setback die.
  */
 
-import GenesysDie from '@/dice/types/GenesysDie';
+import GenesysDie, { DieCategory } from '@/dice/types/GenesysDie';
 
 /**
  * Setback (black) Die
  */
 export default class SetbackDie extends GenesysDie {
 	static override DENOMINATION = 's';
+	static override GLYPH = 'S';
+	static override FORMULA = 'ds';
+	static override CATEGORY = 'negative' as DieCategory;
 	static override FACES = [' ', ' ', 'f', 'f', 'h', 'h'];
 }

--- a/src/scss/chat/sidebar.scss
+++ b/src/scss/chat/sidebar.scss
@@ -1,0 +1,5 @@
+#chat-controls {
+	& > .chat-control-icon {
+		cursor: pointer;
+	}
+}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,5 +1,6 @@
 @import 'chat/chat-message';
 @import 'chat/rolls';
+@import 'chat/sidebar';
 @import 'combat-tracker';
 @import 'nav';
 @import 'tooltip';

--- a/src/settings/campaign.ts
+++ b/src/settings/campaign.ts
@@ -6,6 +6,8 @@
  * @file System settings data related to campaign setting customization.
  */
 
+import { GENESYS_CONFIG } from '@/config';
+
 /**
  * The Skills Compendium to use for default skill data.
  */
@@ -37,11 +39,6 @@ export const KEY_CAREER_SKILL_RANKS = 'careerSkillRanks';
 export const KEY_UNCOUPLE_SKILLS_FROM_CHARACTERISTICS = 'uncoupleSkills';
 
 /**
- * Default skills compendium to use if the setting is misconfigured.
- */
-export const DEFAULT_SKILLS_COMPENDIUM = 'genesys.crb-skills';
-
-/**
  * Whether to show Damage, Critical, and Qualities on attack roll chat cards even when the roll was a failure.
  */
 export const KEY_SHOW_DAMAGE_ON_FAILURE = 'showDamageOnFailure';
@@ -61,8 +58,11 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.SkillsCompendiumHint'),
 		scope: 'world',
 		config: true,
-		default: DEFAULT_SKILLS_COMPENDIUM,
+		default: GENESYS_CONFIG.skillsCompendium,
 		type: String,
+		onChange: (value) => {
+			CONFIG.genesys.skillsCompendium = value ?? '';
+		},
 	});
 
 	game.settings.register(namespace, KEY_SKILL_FOR_INJURIES, {
@@ -70,8 +70,11 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.SkillForInjuriesHint'),
 		scope: 'world',
 		config: true,
-		default: 'Resilience',
+		default: GENESYS_CONFIG.skillForHealingInjury,
 		type: String,
+		onChange: (value) => {
+			CONFIG.genesys.skillForHealingInjury = value ?? '';
+		},
 	});
 
 	game.settings.register(namespace, KEY_SKILL_FOR_REPAIRING_VEHICLE_HITS, {
@@ -79,8 +82,11 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.SkillForRepairingVehicleHitsHint'),
 		scope: 'world',
 		config: true,
-		default: 'Mechanics',
+		default: GENESYS_CONFIG.skillForRepairingHit,
 		type: String,
+		onChange: (value) => {
+			CONFIG.genesys.skillForRepairingHit = value ?? '';
+		},
 	});
 
 	game.settings.register(namespace, KEY_MONEY_NAME, {
@@ -88,8 +94,11 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.MoneyHint'),
 		scope: 'world',
 		config: true,
-		default: 'Money',
+		default: GENESYS_CONFIG.currencyName,
 		type: String,
+		onChange: (value) => {
+			CONFIG.genesys.currencyName = value ?? '';
+		},
 	});
 
 	game.settings.register(namespace, KEY_CAREER_SKILL_RANKS, {
@@ -97,8 +106,12 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.CareerSkillRanksHint'),
 		scope: 'world',
 		config: true,
-		default: 4,
+		default: GENESYS_CONFIG.freeCareerSkillRanks,
 		type: Number,
+		onChange: (value) => {
+			const valueAsInt = Math.floor(Math.abs((value as unknown as number) ?? 0));
+			CONFIG.genesys.freeCareerSkillRanks = valueAsInt;
+		},
 	});
 
 	game.settings.register(namespace, KEY_UNCOUPLE_SKILLS_FROM_CHARACTERISTICS, {
@@ -106,8 +119,12 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.UncoupleSkillsAlternateRuleHint'),
 		scope: 'world',
 		config: true,
-		default: false,
+		default: GENESYS_CONFIG.uncoupleSkillsFromCharacteristics,
 		type: Boolean,
+		onChange: (value) => {
+			const valueAsBool = (value as unknown as boolean) ?? false;
+			CONFIG.genesys.uncoupleSkillsFromCharacteristics = valueAsBool;
+		},
 	});
 
 	game.settings.register(namespace, KEY_SHOW_DAMAGE_ON_FAILURE, {
@@ -115,8 +132,12 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.ShowDamageOnFailureHint'),
 		scope: 'world',
 		config: true,
-		default: false,
+		default: GENESYS_CONFIG.showAttackDetailsOnFailure,
 		type: Boolean,
+		onChange: (value) => {
+			const valueAsBool = (value as unknown as boolean) ?? false;
+			CONFIG.genesys.showAttackDetailsOnFailure = valueAsBool;
+		},
 	});
 
 	game.settings.register(namespace, KEY_SUPER_CHARACTERISTICS, {
@@ -124,7 +145,11 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.SuperCharacteristicsHint'),
 		scope: 'world',
 		config: true,
-		default: false,
+		default: GENESYS_CONFIG.useSuperCharacteristics,
 		type: Boolean,
+		onChange: (value) => {
+			const valueAsBool = (value as unknown as boolean) ?? false;
+			CONFIG.genesys.useSuperCharacteristics = valueAsBool;
+		},
 	});
 }

--- a/src/settings/user.ts
+++ b/src/settings/user.ts
@@ -6,6 +6,8 @@
  * @file User-specific config options.
  */
 
+import { GENESYS_CONFIG } from '@/config';
+
 /**
  * Whether the user wishes to use the Magical Girl symbols.
  */
@@ -27,7 +29,7 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.UseMagicalGirlSymbolsHint'),
 		scope: 'client',
 		config: true,
-		default: false,
+		default: GENESYS_CONFIG.useMagicalGirlSymbols,
 		type: Boolean,
 		requiresReload: true,
 	});
@@ -40,7 +42,7 @@ export function register(namespace: string) {
 			hint: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedByPermutationHint'),
 			scope: 'client',
 			config: true,
-			default: false,
+			default: GENESYS_CONFIG.showChanceToSucceedFromPermutations,
 			type: Boolean,
 			requiresReload: true,
 		});
@@ -51,7 +53,12 @@ export function register(namespace: string) {
 		hint: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedBySimulationHint'),
 		scope: 'client',
 		config: true,
-		default: 0,
+		default: GENESYS_CONFIG.showChanceToSucceedFromSimulations.amountOfRolls,
 		type: Number,
+		onChange: (value) => {
+			const valueAsInt = Math.floor(Math.abs((value as unknown as number) ?? 0));
+			CONFIG.genesys.showChanceToSucceedFromSimulations.enabled = valueAsInt > 0;
+			CONFIG.genesys.showChanceToSucceedFromSimulations.amountOfRolls = valueAsInt;
+		},
 	});
 }

--- a/src/vue/apps/CareerSkillPrompt.vue
+++ b/src/vue/apps/CareerSkillPrompt.vue
@@ -2,8 +2,6 @@
 import { computed, inject, ref } from 'vue';
 
 import { CareerSkillPromptContext } from '@/app/CareerSkillPrompt';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_CAREER_SKILL_RANKS } from '@/settings/campaign';
 import { RootContext } from '@/vue/SheetContext';
 import Localized from '@/vue/components/Localized.vue';
 import SkillDataModel from '@/item/data/SkillDataModel';
@@ -12,7 +10,7 @@ import GenesysItem from '@/item/GenesysItem';
 const context = inject<CareerSkillPromptContext>(RootContext)!;
 
 const selectedSkillIDs = ref<string[]>([]);
-const remaining = computed(() => (game.settings.get(SETTINGS_NAMESPACE, KEY_CAREER_SKILL_RANKS) as number) - selectedSkillIDs.value.length);
+const remaining = computed(() => CONFIG.genesys.freeCareerSkillRanks - selectedSkillIDs.value.length);
 
 function selectSkill(event: Event, skill: GenesysItem<SkillDataModel>) {
 	event.preventDefault();

--- a/src/vue/components/character/Characteristic.vue
+++ b/src/vue/components/character/Characteristic.vue
@@ -2,8 +2,6 @@
 import ContextMenu from '@/vue/components/ContextMenu.vue';
 import Localized from '@/vue/components/Localized.vue';
 import MenuItem from '@/vue/components/MenuItem.vue';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_SUPER_CHARACTERISTICS } from '@/settings/campaign';
 
 withDefaults(
 	defineProps<{
@@ -62,7 +60,7 @@ const emit = defineEmits<{
 	(e: 'toggleSuper'): void;
 }>();
 
-const allowSuperCharacteristics = game.settings.get(SETTINGS_NAMESPACE, KEY_SUPER_CHARACTERISTICS) as boolean;
+const allowSuperCharacteristics = CONFIG.genesys.useSuperCharacteristics;
 const markSuperCharacteristicLabel = game.i18n.localize('Genesys.Labels.MarkSuperCharacteristic');
 const unmarkSuperCharacteristicLabel = game.i18n.localize('Genesys.Labels.UnmarkSuperCharacteristic');
 </script>

--- a/src/vue/components/inventory/InventoryItem.vue
+++ b/src/vue/components/inventory/InventoryItem.vue
@@ -73,8 +73,8 @@ const weaponDamage = computed(() => {
 });
 
 async function rollAttack() {
-	const [_, skillId] = skillForWeapon();
-	await DicePrompt.promptForRoll(toRaw(rootContext.data.actor), skillId, {
+	const [skillName] = skillForWeapon();
+	await DicePrompt.promptForRoll(toRaw(rootContext.data.actor), skillName, {
 		rollType: RollType.Attack,
 		rollData: {
 			weapon: props.item,

--- a/src/vue/sheets/actor/AdversarySheet.vue
+++ b/src/vue/sheets/actor/AdversarySheet.vue
@@ -54,11 +54,11 @@ function updateEffects() {
 }
 
 async function rollSkill(skill: GenesysItem<SkillDataModel>) {
-	await DicePrompt.promptForRoll(toRaw(context.data.actor), skill.id);
+	await DicePrompt.promptForRoll(toRaw(context.data.actor), skill.name);
 }
 
 async function rollUnskilled(characteristic: CharacteristicType) {
-	await DicePrompt.promptForRoll(toRaw(context.data.actor), '-', { rollUnskilled: characteristic });
+	await DicePrompt.promptForRoll(toRaw(context.data.actor), '', { rollUnskilled: characteristic });
 }
 
 async function rollAttack(weapon: GenesysItem) {
@@ -66,7 +66,7 @@ async function rollAttack(weapon: GenesysItem) {
 		return;
 	}
 
-	await DicePrompt.promptForRoll(toRaw(context.data.actor), skillForWeapon(weapon)[1], { rollType: RollType.Attack, rollData: { weapon } });
+	await DicePrompt.promptForRoll(toRaw(context.data.actor), skillForWeapon(weapon)[0], { rollType: RollType.Attack, rollData: { weapon } });
 }
 
 async function editItem(item: GenesysItem) {

--- a/src/vue/sheets/actor/MinionSheet.vue
+++ b/src/vue/sheets/actor/MinionSheet.vue
@@ -22,7 +22,7 @@ const editLabel = game.i18n.localize('Genesys.Labels.Edit');
 const deleteLabel = game.i18n.localize('Genesys.Labels.Delete');
 
 async function rollSkill(skill: GenesysItem<SkillDataModel>) {
-	await DicePrompt.promptForRoll(toRaw(context.data.actor), skill.id);
+	await DicePrompt.promptForRoll(toRaw(context.data.actor), skill.name);
 }
 
 async function editItem(item: GenesysItem) {

--- a/src/vue/sheets/actor/character/CombatTab.vue
+++ b/src/vue/sheets/actor/character/CombatTab.vue
@@ -10,8 +10,6 @@ import Enriched from '@/vue/components/Enriched.vue';
 import InjuryDataModel from '@/item/data/InjuryDataModel';
 import SkillDataModel from '@/item/data/SkillDataModel';
 import DicePrompt, { RollType } from '@/app/DicePrompt';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_SKILL_FOR_INJURIES } from '@/settings/campaign';
 import SkillRanks from '@/vue/components/character/SkillRanks.vue';
 import Tooltip from '@/vue/components/Tooltip.vue';
 
@@ -40,7 +38,7 @@ async function deleteItem(item: GenesysItem) {
 }
 
 async function rollAttack(weapon: GenesysItem<WeaponDataModel>) {
-	await DicePrompt.promptForRoll(toRaw(rootContext.data.actor), skillForWeapon(weapon)?.id ?? '-', {
+	await DicePrompt.promptForRoll(toRaw(rootContext.data.actor), skillForWeapon(weapon)?.name ?? '', {
 		rollType: RollType.Attack,
 		rollData: {
 			weapon,
@@ -49,12 +47,8 @@ async function rollAttack(weapon: GenesysItem<WeaponDataModel>) {
 }
 
 async function healInjury(injury: GenesysItem<InjuryDataModel>) {
-	const resilienceSkillName = game.settings.get(SETTINGS_NAMESPACE, KEY_SKILL_FOR_INJURIES) as string;
-
-	const resilienceSkill = toRaw(rootContext.data.actor).items.find((s) => s.name.toLowerCase() === resilienceSkillName.toLowerCase());
-
-	await DicePrompt.promptForRoll(toRaw(rootContext.data.actor), resilienceSkill?.id ?? '-', {
-		startingDifficulty: SEVERITY_TO_DIFFICULTY[injury.systemData.severity],
+	await DicePrompt.promptForRoll(toRaw(rootContext.data.actor), CONFIG.genesys.skillForHealingInjury, {
+		difficulty: SEVERITY_TO_DIFFICULTY[injury.systemData.severity],
 	});
 }
 

--- a/src/vue/sheets/actor/character/InventoryTab.vue
+++ b/src/vue/sheets/actor/character/InventoryTab.vue
@@ -2,8 +2,6 @@
 import { computed, inject, ref, toRaw } from 'vue';
 import { ActorSheetContext, RootContext } from '@/vue/SheetContext';
 import CharacterDataModel from '@/actor/data/CharacterDataModel';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_MONEY_NAME } from '@/settings/campaign';
 import Localized from '@/vue/components/Localized.vue';
 import EquipmentDataModel, { EquipmentState } from '@/item/data/EquipmentDataModel';
 import GenesysItem from '@/item/GenesysItem';
@@ -24,7 +22,7 @@ const droppedItems = computed(() => inventory.value.filter((i) => i.systemData.s
 
 const draggingItem = ref(false);
 
-const CURRENCY_LABEL = game.settings.get(SETTINGS_NAMESPACE, KEY_MONEY_NAME);
+const CURRENCY_LABEL = CONFIG.genesys.currencyName;
 
 function sortItems(left: GenesysItem, right: GenesysItem) {
 	return left.sort - right.sort;

--- a/src/vue/sheets/actor/character/SkillsTab.vue
+++ b/src/vue/sheets/actor/character/SkillsTab.vue
@@ -46,11 +46,11 @@ const editLabel = game.i18n.localize('Genesys.Labels.Edit');
 const deleteLabel = game.i18n.localize('Genesys.Labels.Delete');
 
 async function rollSkill(skill: GenesysItem<SkillDataModel>) {
-	await DicePrompt.promptForRoll(toRaw(context.data.actor), skill.id);
+	await DicePrompt.promptForRoll(toRaw(context.data.actor), skill.name);
 }
 
 async function rollUnskilled(characteristic: CharacteristicType) {
-	await DicePrompt.promptForRoll(toRaw(context.data.actor), '-', { rollUnskilled: characteristic });
+	await DicePrompt.promptForRoll(toRaw(context.data.actor), '', { rollUnskilled: characteristic });
 }
 
 async function purchaseCharacteristic(characteristic: keyof typeof system.value.characteristics) {

--- a/src/vue/sheets/actor/vehicle/CombatTab.vue
+++ b/src/vue/sheets/actor/vehicle/CombatTab.vue
@@ -17,9 +17,6 @@ import Tooltip from '@/vue/components/Tooltip.vue';
 
 import SelectCharacterSkillPrompt, { CharacterSkillOption } from '@/app/SelectCharacterSkillPrompt';
 
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_SKILL_FOR_REPAIRING_VEHICLE_HITS } from '@/settings/campaign';
-
 const rootContext = inject<ActorSheetContext<VehicleDataModel>>(RootContext)!;
 
 const actor = computed(() => toRaw(rootContext.data.actor));
@@ -80,14 +77,14 @@ async function pickAttackerAndRollAttack(weapon: GenesysItem<VehicleWeaponDataMo
 		return;
 	}
 
-	await DicePrompt.promptForRoll(selectAttacker.actor, selectAttacker.skill.id, {
+	await DicePrompt.promptForRoll(selectAttacker.actor, selectAttacker.skill.name, {
 		rollType: RollType.Attack,
 		rollData: { weapon },
 	});
 }
 
 async function repairHit(criticalHit: GenesysItem<InjuryDataModel>) {
-	const skillNameForRepairing = game.settings.get(SETTINGS_NAMESPACE, KEY_SKILL_FOR_REPAIRING_VEHICLE_HITS) as string;
+	const skillNameForRepairing = CONFIG.genesys.skillForRepairingHit;
 	const relevantRoles = actor.value.systemData.roles.filter((role) => role.skills.includes(skillNameForRepairing));
 	const potentialRepairer = relevantRoles.reduce((accum, role) => {
 		for (const member of role.members) {
@@ -114,8 +111,8 @@ async function repairHit(criticalHit: GenesysItem<InjuryDataModel>) {
 		return;
 	}
 
-	await DicePrompt.promptForRoll(selectRepairer.actor, selectRepairer.skill.id, {
-		startingDifficulty: SEVERITY_TO_DIFFICULTY[criticalHit.systemData.severity],
+	await DicePrompt.promptForRoll(selectRepairer.actor, selectRepairer.skill.name, {
+		difficulty: SEVERITY_TO_DIFFICULTY[criticalHit.systemData.severity],
 	});
 }
 </script>

--- a/src/vue/sheets/actor/vehicle/InventoryTab.vue
+++ b/src/vue/sheets/actor/vehicle/InventoryTab.vue
@@ -7,14 +7,12 @@ import GenesysItem from '@/item/GenesysItem';
 import VehicleDataModel from '@/actor/data/VehicleDataModel';
 import EquipmentDataModel, { EquipmentState } from '@/item/data/EquipmentDataModel';
 import GenesysEffect from '@/effects/GenesysEffect';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_MONEY_NAME } from '@/settings/campaign';
 
 import Localized from '@/vue/components/Localized.vue';
 import InventorySortSlot from '@/vue/components/inventory/InventorySortSlot.vue';
 import InventoryItem from '@/vue/components/inventory/InventoryItem.vue';
 
-const CURRENCY_LABEL = game.settings.get(SETTINGS_NAMESPACE, KEY_MONEY_NAME);
+const CURRENCY_LABEL = CONFIG.genesys.currencyName;
 
 const context = inject<ActorSheetContext<VehicleDataModel>>(RootContext)!;
 const system = computed(() => toRaw(context.data.actor).systemData);

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -51,7 +51,7 @@ const dataGroupedByMember = computed(() =>
 
 async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDataModel>) {
 	if (actor.isOwner) {
-		await DicePrompt.promptForRoll(actor, skill.id);
+		await DicePrompt.promptForRoll(actor, skill.name);
 	}
 }
 

--- a/types/foundry/client/core/hooks.d.ts
+++ b/types/foundry/client/core/hooks.d.ts
@@ -60,6 +60,7 @@ declare global {
 		static on(...args: HookParamsRender<TokenHUD, 'TokenHUD'>): number;
 		static on(...args: HookParamsRender<JournalPageSheet, 'JournalPageSheet'>): number;
 		static on(...args: HookParamsRender<JournalTextPageSheet, 'JournalTextPageSheet'>): number;
+		static on(...args: HookParamsRender<SidebarTab, 'SidebarTab'>): number;
 		static on(...args: HookParamsTargetToken): number;
 		static on(...args: HookParamsUpdate<Combat, 'Combat'>): number;
 		static on(...args: HookParamsUpdate<Scene, 'Scene'>): number;
@@ -99,6 +100,7 @@ declare global {
 		static once(...args: HookParamsRender<SceneControls, 'SceneControls'>): number;
 		static once(...args: HookParamsRender<Settings, 'Settings'>): number;
 		static once(...args: HookParamsRender<TokenHUD, 'TokenHUD'>): number;
+		static once(...args: HookParamsRender<SidebarTab, 'SidebarTab'>): number;
 		static once(...args: HookParamsTargetToken): number;
 		static once(...args: HookParamsUpdate<Combat, 'Combat'>): number;
 		static once(...args: HookParamsUpdate<Scene, 'Scene'>): number;

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -50,8 +50,8 @@ Genesys:
     DicePoolChanceToSucceedByPermutation: Calculate the Chance to Succeed for Dice Pools
     DicePoolChanceToSucceedByPermutationHint: >-
       If enabled this will spawn a Web Worker that calculates the exact chance to succeed.
-      However, if the dice pool uses a super characteristic the calculated value is lower than the true value because it assumes that the pool doesn't explode.
-      For dice pools that use super characteristics you can get a more accurate value by using simulations.
+      However, if the dice pool uses a super-characteristic the calculated value is lower than the true value because it assumes that the pool doesn't explode.
+      For dice pools that use super-characteristics you can get a more accurate value by using simulations.
     DicePoolChanceToSucceedBySimulation: Approximate the Chance to Succeed for Dice Pools
     DicePoolChanceToSucceedBySimulationHint: >-
       The number of simulated rolls to run in order to approximate the chance to succeed.
@@ -72,6 +72,7 @@ Genesys:
     Dice: Dice
     Results: Roll Results
     Description:
+      Simple: Rolling...
       Initiative: Rolling Initiative with <strong>{skill}</strong>...
       Characteristic: Rolling <strong>{characteristic}</strong>...
       Skill: Rolling <strong>{skill} ({characteristic})</strong>...
@@ -148,8 +149,9 @@ Genesys:
     Title: Dice Pool
     Roll: Roll!
     Hint: Use the dice box on the right to add, upgrade, and downgrade. Click dice in the pool to remove them!
+    UseSuperCharacteristic: Roll as a super-characteristic
     ChanceToSucceed: 'Chance to Succeed:'
-    ChanceToSucceedByPermutationDisclaimer: The displayed probability is exact unless the dice pool includes a super characteristic.
+    ChanceToSucceedByPermutationDisclaimer: The displayed probability is exact unless the dice pool includes a super-characteristic.
     ChanceToSucceedBySimulationDisclaimer: The displayed probability is an approximation that uses the Monte Carlo method.
 
   # Experience Journal Labels
@@ -178,9 +180,11 @@ Genesys:
     CannotPurchaseTalentTier: Cannot purchase talents at tier {tier} - you must have at least {minimum} talents at rank {lowerTier} first.
     NotEnoughStoryPoints: You can't spend Story Points you don't have!
     SelectOneTokenForAction: You need to selected a single token to perform this action.
+    SelectNoneOrOneTokenForAction: You need to select no tokens, or a single token, to perform this action.
     TokenIsNotCombatant: The selected token is not participating on the current combat.
     CannotClaimOppositeSlot: You can't claim this initiative slot with {name} - it's on the wrong side!
     CannotSelectActor: You do not have sufficient permission to select this Actor.
+    InvalidTokenTypeForAction: The selected token is of an invalid type to perform this action.
 
   # Story Points
   StoryPoints:


### PR DESCRIPTION
This PR contains the necessary changes to allow an user to bring up the dice prompt without having to go through a sheet. In summary these are the changes made:

- Moved some information about the dice from the dice prompt into the dice classes.
- Expanded the `CONFIG.genesys` object to contains all the system settings.
  - The code now uses said object instead of getting the setting directly.
- The dice prompt no longer depends on an actor to pull data
  - To be more precise, if no actor is provided it simply presents a simpler prompt.
  - If the super-characteristics setting is enabled then a checkbox will appear to signal the roller that this pool is using a super-characteristic.
- Added a hook that adds a listener to the dice icon on the chat which lets users call on the dice prompt.
  - If a single non-vehicle actor token is selected then the list of skills will be presented. I no token is selected then it brings up the simplified version.

![Dice Prompt - Simplified Version](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/b0125a6d-ef5e-498b-a1b9-c60ac0b06987)

