### PR TITLE
Fix sending items to chat with no damage

### DIFF
--- a/src/vue/components/inventory/InventoryItem.vue
+++ b/src/vue/components/inventory/InventoryItem.vue
@@ -123,13 +123,13 @@ async function sendItemToChat() {
 		weapon = {
 			skill: weaponData.value.charWeapon.skills[0] ?? '-',
 			damage:
-				weaponData.value.charWeapon.baseDamage.toString() +
+				(weaponData.value.charWeapon.baseDamage ?? 0).toString() +
 				(weaponData.value.charWeapon.damageCharacteristic !== '-' ? ' + ' + game.i18n.localize(`Genesys.CharacteristicAbbr.${weaponData.value.charWeapon.damageCharacteristic.capitalize()}`) : ''),
 		};
 	} else if (props.item.type === 'vehicleWeapon') {
 		weapon = {
 			skill: weaponData.value.vehWeapon.skills[0] ?? '-',
-			damage: weaponData.value.vehWeapon.baseDamage.toString(),
+			damage: (weaponData.value.vehWeapon.baseDamage ?? 0).toString(),
 			firingArc: getFiringArcLabels(weaponData.value.vehWeapon).join(', '),
 		};
 	}


### PR DESCRIPTION
Weapons that had no value set for their damage were not being properly sent to the chat. The changes here fixes it.