### PR TITLE
Use old format for symbols for GenesysRoller

### DIFF
--- a/public/scripts/calculate-chance-worker.js
+++ b/public/scripts/calculate-chance-worker.js
@@ -503,9 +503,10 @@ const cacheForPool = {};
 /**
  * This function proccessed the input and relays the data to the functions that calculate the chance of
  * meeting the specified criteria.
- * @param {Record<string, number>} dicePool - A pool of dice with their types and amount.
- * @param {Record<string, number>} extraSymbols - A collection of extra symbols to add to the result.
- * @param {string} criteriaType - The type of criteria to use when calculating the chance of achieving it.
+ * @param {Object} poolData - The object that has all the pool information.
+ * @param {Record<string, number>} poolData.dicePool - A pool of dice with their types and amount.
+ * @param {Record<string, number>} poolData.extraSymbols - A collection of extra symbols to add to the result.
+ * @param {string} poolData.criteriaType - The type of criteria to use when calculating the chance of achieving it.
  * @returns {Promise<number>} The chance (as a ratio) of a dice pool to meet the specified criteria.
  */
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -- This is used by the Dice Prompt.

--- a/public/scripts/calculate-chance-worker.js
+++ b/public/scripts/calculate-chance-worker.js
@@ -511,7 +511,7 @@ const cacheForPool = {};
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -- This is used by the Dice Prompt.
 async function calculateChanceForDicePool({ dicePool, extraSymbols, criteriaType }) {
 	const processedDicePool = Object.entries(dicePool ?? {}).reduce((accum, [denomination, amount]) => {
-		const targetDice = DiceFromDenomination.get(denomination);
+		const targetDice = Dice[denomination];
 		const targetDiceAmount = parseInt(amount, 10);
 
 		if (targetDice && targetDiceAmount > 0) {
@@ -522,7 +522,7 @@ async function calculateChanceForDicePool({ dicePool, extraSymbols, criteriaType
 	const dicePoolAsString = constructKeyFromMixedPool(processedDicePool);
 
 	const processedExtraSymbols = Object.entries(extraSymbols ?? {}).reduce((accum, [denomination, amount]) => {
-		const targetSymbol = SymbolFromDenomination.get(denomination);
+		const targetSymbol = Symbols[denomination];
 		const targetSymbolAmount = parseInt(amount, 10);
 
 		if (targetSymbol && targetSymbolAmount > 0) {

--- a/public/scripts/calculate-chance-worker.js
+++ b/public/scripts/calculate-chance-worker.js
@@ -510,8 +510,8 @@ const cacheForPool = {};
  */
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -- This is used by the Dice Prompt.
 async function calculateChanceForDicePool({ dicePool, extraSymbols, criteriaType }) {
-	const processedDicePool = Object.entries(dicePool ?? {}).reduce((accum, [denomination, amount]) => {
-		const targetDice = Dice[denomination];
+	const processedDicePool = Object.entries(dicePool ?? {}).reduce((accum, [name, amount]) => {
+		const targetDice = Dice[name];
 		const targetDiceAmount = parseInt(amount, 10);
 
 		if (targetDice && targetDiceAmount > 0) {
@@ -521,8 +521,8 @@ async function calculateChanceForDicePool({ dicePool, extraSymbols, criteriaType
 	}, new Map());
 	const dicePoolAsString = constructKeyFromMixedPool(processedDicePool);
 
-	const processedExtraSymbols = Object.entries(extraSymbols ?? {}).reduce((accum, [denomination, amount]) => {
-		const targetSymbol = Symbols[denomination];
+	const processedExtraSymbols = Object.entries(extraSymbols ?? {}).reduce((accum, [name, amount]) => {
+		const targetSymbol = Symbols[name];
 		const targetSymbolAmount = parseInt(amount, 10);
 
 		if (targetSymbol && targetSymbolAmount > 0) {


### PR DESCRIPTION
> Fixes #114

In a previous PR the format to represent dice and symbols changed on the `DicePrompt` class. However, some of the values are forwarded to the `GenesysRoller` class which doesn't have these changes. Since I plan to heavily (potentially) refactor said class down the line I'm just converting the object we pass to it instead of changing how the class interprets it.

Additionally, this was also was breaking the calculations for chance to succeed for both methods so I fixed those as well.