### PR TITLE
Displays the source field in the description

### DIFF
--- a/src/vue/sheets/actor/character/JournalTab.vue
+++ b/src/vue/sheets/actor/character/JournalTab.vue
@@ -187,6 +187,7 @@ async function addXPJournalEntry() {
 		padding: 0.75em;
 
 		&.experience {
+			background: none;
 			grid-column: 1 / span all;
 			display: grid;
 			grid-template-columns: auto 1fr auto;

--- a/src/vue/sheets/item/ArchetypeSheet.vue
+++ b/src/vue/sheets/item/ArchetypeSheet.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, inject } from 'vue';
+import { computed, inject, ref, watchEffect } from 'vue';
 
 import { ItemSheetContext, RootContext } from '@/vue/SheetContext';
 import BasicItemSheet from '@/vue/sheets/item/BasicItemSheet.vue';
@@ -12,8 +12,13 @@ import Enriched from '@/vue/components/Enriched.vue';
 import Characteristic from '@/vue/components/character/Characteristic.vue';
 
 const context = inject<ItemSheetContext<ArchetypeDataModel>>(RootContext)!;
-
 const system = computed(() => context.data.item.systemData);
+
+const source = ref('');
+
+watchEffect(async () => {
+	source.value = await TextEditor.enrichHTML(system.value.source, { async: true });
+});
 
 const abilitiesHeaderWords = game.i18n.localize('Genesys.Archetype.Abilities').split(' ');
 
@@ -35,6 +40,7 @@ async function deleteGrantedItem(index: number) {
 			<section class="overview">
 				<section class="description">
 					<Editor name="system.description" :content="system.description" button />
+					<div class="source" v-html="source" />
 				</section>
 
 				<section class="stats">

--- a/src/vue/sheets/item/BasicItemSheet.vue
+++ b/src/vue/sheets/item/BasicItemSheet.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, inject, onBeforeMount, onBeforeUpdate, ref, toRaw } from 'vue';
+import { computed, inject, onBeforeMount, onBeforeUpdate, ref, toRaw, watchEffect } from 'vue';
 
 import { vLocalize } from '@/vue/directives';
 import { ItemSheetContext, RootContext } from '@/vue/SheetContext';
@@ -26,6 +26,11 @@ const system = computed(() => context.data.item.systemData);
 //   1. Use an 'any' typing to skirt around TypeScript's complaints.
 //   2. Keep a local ref that gets updated in onBeforeUpdate in order to work around some struggles with Foundry.
 const effects = ref<any>([]);
+const source = ref('');
+
+watchEffect(async () => {
+	source.value = await TextEditor.enrichHTML(system.value.source, { async: true });
+});
 
 async function addEffect(category: string) {
 	await toRaw(context.sheet.item).createEmbeddedDocuments('ActiveEffect', [
@@ -78,7 +83,10 @@ onBeforeUpdate(updateEffects);
 		<section class="sheet-body">
 			<div class="tab" data-group="primary" data-tab="description">
 				<slot name="description">
-					<Editor name="system.description" :content="system.description" button />
+					<section class="description">
+						<Editor name="system.description" :content="system.description" button />
+						<div class="source" v-html="source" />
+					</section>
 				</slot>
 			</div>
 
@@ -110,6 +118,27 @@ onBeforeUpdate(updateEffects);
 	.editor-content {
 		font-family: 'Roboto Serif', serif;
 		text-align: justify;
+	}
+
+	.description {
+		display: flex;
+		flex-direction: column;
+
+		.source {
+			width: 100%;
+			font-family: 'Roboto Serif', serif;
+			font-style: italic;
+			font-size: 0.8em;
+			text-align: right;
+			padding-top: 0.25rem;
+			padding-right: 1.5rem;
+			margin-bottom: 0.5rem;
+			border-top: 1px dashed black;
+
+			&:empty {
+				border-top: none;
+			}
+		}
 	}
 
 	header {

--- a/src/vue/sheets/item/CareerSheet.vue
+++ b/src/vue/sheets/item/CareerSheet.vue
@@ -1,14 +1,19 @@
 <script lang="ts" setup>
 import BasicItemSheet from '@/vue/sheets/item/BasicItemSheet.vue';
 import Localized from '@/vue/components/Localized.vue';
-import { computed, inject } from 'vue';
+import { computed, inject, ref, watchEffect } from 'vue';
 import { ItemSheetContext, RootContext } from '@/vue/SheetContext';
 import CareerDataModel from '@/item/data/CareerDataModel';
 import Editor from '@/vue/components/Editor.vue';
 
 const context = inject<ItemSheetContext<CareerDataModel>>(RootContext)!;
-
 const system = computed(() => context.data.item.systemData);
+
+const source = ref('');
+
+watchEffect(async () => {
+	source.value = await TextEditor.enrichHTML(system.value.source, { async: true });
+});
 
 const careerSkillsHeaderWords = game.i18n.localize('Genesys.Career.Skills').split(' ');
 
@@ -28,6 +33,7 @@ async function removeSkill(index: number) {
 			<section class="overview">
 				<section class="description">
 					<Editor name="system.description" :content="system.description" button />
+					<div class="source" v-html="source" />
 				</section>
 
 				<section class="stats">


### PR DESCRIPTION
- Display the source field in the description area after being enriched
  - Addresses #43 
- Removes the light blue background that was showing around the XP containers on the character's Journal tab.

**_Item with enrichable source_**
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/5b1c0652-85d2-4a5a-9fff-00e461fb76a7)

**_Enriched source_**
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/ef93c191-2aeb-4844-ba13-cfd49cbcbc1e)