### PR TITLE
Fixes drag & drop highlight not working on Chrome/app

### DIFF
--- a/src/data/DragTransferData.ts
+++ b/src/data/DragTransferData.ts
@@ -19,3 +19,28 @@ export type CrewDragTransferData = DragTransferData &
 	Partial<CrewExtraDragTransferData> & {
 		sourceVehicleUuid?: string;
 	};
+
+const GENESYS_DRAG_TYPE_PREFIX = 'genesys';
+
+export function constructDragTransferTypeFromData(genesysType: string, uuid: ItemUUID | ActorUUID | TokenDocumentUUID) {
+	return `${GENESYS_DRAG_TYPE_PREFIX}/${genesysType}/${uuid}`;
+}
+
+export function extractDataFromDragTransferTypes(dragTransferTypes?: readonly string[]) {
+	if (dragTransferTypes) {
+		const genesysDragType = dragTransferTypes.find((transferType) => transferType.indexOf(GENESYS_DRAG_TYPE_PREFIX) === 0);
+
+		if (genesysDragType) {
+			const genesysDataSections = genesysDragType.split('/');
+
+			if (genesysDataSections.length === 3) {
+				return {
+					genesysType: genesysDataSections[1],
+					uuid: genesysDataSections[2],
+				};
+			}
+		}
+	}
+
+	return null;
+}

--- a/src/vue/components/ActorTile.vue
+++ b/src/vue/components/ActorTile.vue
@@ -3,7 +3,7 @@ import VehicleDataModel from '@/actor/data/VehicleDataModel';
 import { inject, ref, toRaw } from 'vue';
 import { ActorSheetContext, RootContext } from '@/vue/SheetContext';
 import GenesysActor from '@/actor/GenesysActor';
-import { DragTransferData } from '@/data/DragTransferData';
+import { constructDragTransferTypeFromData, DragTransferData } from '@/data/DragTransferData';
 
 import Localized from '@/vue/components/Localized.vue';
 import ContextMenu from '@/vue/components/ContextMenu.vue';
@@ -43,8 +43,10 @@ function dragStart(event: DragEvent) {
 		type: props.actor.documentName,
 		genesysType: props.actor.type,
 	};
+	const genesysTransferType = constructDragTransferTypeFromData(props.actor.type, props.actor.uuid);
 
 	event.dataTransfer?.setData('text/plain', JSON.stringify(transferData));
+	event.dataTransfer?.setData(genesysTransferType, '');
 
 	emit('dragstart', event);
 }

--- a/src/vue/components/inventory/InventoryItem.vue
+++ b/src/vue/components/inventory/InventoryItem.vue
@@ -10,7 +10,7 @@ import WeaponDataModel from '@/item/data/WeaponDataModel';
 import VehicleWeaponDataModel from '@/item/data/VehicleWeaponDataModel';
 import CharacterDataModel from '@/actor/data/CharacterDataModel';
 import VehicleDataModel from '@/actor/data/VehicleDataModel';
-import { DragTransferData } from '@/data/DragTransferData';
+import { constructDragTransferTypeFromData, DragTransferData, extractDataFromDragTransferTypes } from '@/data/DragTransferData';
 import { transferInventoryBetweenActors } from '@/operations/TransferBetweenActors';
 
 import Localized from '@/vue/components/Localized.vue';
@@ -232,8 +232,11 @@ function dragStart(event: DragEvent) {
 		type: props.item.documentName,
 		genesysType: props.item.type,
 	};
+	const genesysTransferType = constructDragTransferTypeFromData(props.item.type, props.item.uuid);
 
 	event.dataTransfer?.setData('text/plain', JSON.stringify(transferData));
+	event.dataTransfer?.setData(genesysTransferType, '');
+
 	emit('dragstart', event);
 }
 
@@ -249,13 +252,8 @@ function dragEnter(event: DragEvent) {
 		return;
 	}
 
-	const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
-	if (!dragData.uuid || (dragData.genesysType && !props.canTypeBeInsideContainer(dragData.genesysType))) {
-		return;
-	}
-
-	const draggedEntity = fromUuidSync(dragData.uuid) as { type: string } | null;
-	if (!draggedEntity || !props.canTypeBeInsideContainer(draggedEntity.type)) {
+	const dragDataFromType = extractDataFromDragTransferTypes(event.dataTransfer?.types);
+	if (!dragDataFromType || (dragDataFromType.genesysType && !props.canTypeBeInsideContainer(dragDataFromType.genesysType))) {
 		return;
 	}
 

--- a/src/vue/sheets/actor/character/InventoryTab.vue
+++ b/src/vue/sheets/actor/character/InventoryTab.vue
@@ -5,7 +5,7 @@ import { ActorSheetContext, RootContext } from '@/vue/SheetContext';
 import CharacterDataModel from '@/actor/data/CharacterDataModel';
 import EquipmentDataModel, { EquipmentState } from '@/item/data/EquipmentDataModel';
 import GenesysItem from '@/item/GenesysItem';
-import { DragTransferData } from '@/data/DragTransferData';
+import { DragTransferData, extractDataFromDragTransferTypes } from '@/data/DragTransferData';
 import { transferInventoryBetweenActors } from '@/operations/TransferBetweenActors';
 
 import Localized from '@/vue/components/Localized.vue';
@@ -140,24 +140,15 @@ async function resetDragCounters(_event: DragEvent) {
 }
 
 function modifyDragCounters(event: DragEvent, direction: number) {
-	let draggedType: string;
-	const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
-	if (dragData.genesysType) {
-		draggedType = dragData.genesysType;
-	} else if (dragData.uuid) {
-		const droppedEntity = fromUuidSync(dragData.uuid) as { type: string } | null;
-		if (!droppedEntity) {
-			return;
-		}
-		draggedType = droppedEntity.type;
-	} else {
+	const dragDataFromType = extractDataFromDragTransferTypes(event.dataTransfer?.types);
+	if (!dragDataFromType) {
 		return;
 	}
 
-	if (CharacterDataModel.isRelevantTypeForContext('EQUIPABLE', draggedType)) {
+	if (CharacterDataModel.isRelevantTypeForContext('EQUIPABLE', dragDataFromType.genesysType)) {
 		dragCounters.value[EquipmentState.Equipped] += direction;
 	}
-	if (CharacterDataModel.isRelevantTypeForContext('INVENTORY', draggedType)) {
+	if (CharacterDataModel.isRelevantTypeForContext('INVENTORY', dragDataFromType.genesysType)) {
 		dragCounters.value[EquipmentState.Carried] += direction;
 		dragCounters.value[EquipmentState.Dropped] += direction;
 	}

--- a/src/vue/sheets/actor/vehicle/CrewTab.vue
+++ b/src/vue/sheets/actor/vehicle/CrewTab.vue
@@ -9,7 +9,7 @@ import SortSlot from '@/vue/components/inventory/SortSlot.vue';
 import ActorTile from '@/vue/components/ActorTile.vue';
 
 import GenesysActor from '@/actor/GenesysActor';
-import { CrewDragTransferData, CrewExtraDragTransferData } from '@/data/DragTransferData';
+import { CrewDragTransferData, CrewExtraDragTransferData, extractDataFromDragTransferTypes } from '@/data/DragTransferData';
 
 type FromUuidSimpleReturnData = null | {
 	name: string;
@@ -237,24 +237,15 @@ async function resetDragCounters(_event: DragEvent) {
 }
 
 function modifyDragCounters(event: DragEvent, direction: number) {
-	let draggedType: string;
-	const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as CrewDragTransferData;
-	if (dragData.genesysType) {
-		draggedType = dragData.genesysType;
-	} else if (dragData.uuid) {
-		const droppedEntity = fromUuidSync(dragData.uuid) as FromUuidSimpleReturnData;
-		if (!droppedEntity) {
-			return;
-		}
-		draggedType = droppedEntity.type;
-	} else {
+	const dragDataFromType = extractDataFromDragTransferTypes(event.dataTransfer?.types);
+	if (!dragDataFromType) {
 		return;
 	}
 
-	if (VehicleDataModel.isRelevantTypeForContext('ROLE', draggedType)) {
+	if (VehicleDataModel.isRelevantTypeForContext('ROLE', dragDataFromType.genesysType)) {
 		dragCounters.value.role += direction;
 	}
-	if (VehicleDataModel.isRelevantTypeForContext('PASSENGER', draggedType)) {
+	if (VehicleDataModel.isRelevantTypeForContext('PASSENGER', dragDataFromType.genesysType)) {
 		dragCounters.value.passenger += direction;
 	}
 }

--- a/src/vue/sheets/actor/vehicle/InventoryTab.vue
+++ b/src/vue/sheets/actor/vehicle/InventoryTab.vue
@@ -5,7 +5,7 @@ import { ActorSheetContext, RootContext } from '@/vue/SheetContext';
 import GenesysItem from '@/item/GenesysItem';
 import VehicleDataModel from '@/actor/data/VehicleDataModel';
 import EquipmentDataModel, { EquipmentState } from '@/item/data/EquipmentDataModel';
-import { DragTransferData } from '@/data/DragTransferData';
+import { DragTransferData, extractDataFromDragTransferTypes } from '@/data/DragTransferData';
 import { transferInventoryBetweenActors } from '@/operations/TransferBetweenActors';
 
 import Localized from '@/vue/components/Localized.vue';
@@ -133,24 +133,15 @@ async function resetDragCounters(_event: DragEvent) {
 }
 
 function modifyDragCounters(event: DragEvent, direction: number) {
-	let draggedType: string;
-	const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
-	if (dragData.genesysType) {
-		draggedType = dragData.genesysType;
-	} else if (dragData.uuid) {
-		const droppedEntity = fromUuidSync(dragData.uuid) as { type: string } | null;
-		if (!droppedEntity) {
-			return;
-		}
-		draggedType = droppedEntity.type;
-	} else {
+	const dragDataFromType = extractDataFromDragTransferTypes(event.dataTransfer?.types);
+	if (!dragDataFromType) {
 		return;
 	}
 
-	if (VehicleDataModel.isRelevantTypeForContext('EQUIPABLE', draggedType)) {
+	if (VehicleDataModel.isRelevantTypeForContext('EQUIPABLE', dragDataFromType.genesysType)) {
 		dragCounters.value[EquipmentState.Equipped] += direction;
 	}
-	if (VehicleDataModel.isRelevantTypeForContext('INVENTORY', draggedType)) {
+	if (VehicleDataModel.isRelevantTypeForContext('INVENTORY', dragDataFromType.genesysType)) {
 		dragCounters.value[EquipmentState.Carried] += direction;
 	}
 }


### PR DESCRIPTION
The `dataTransfer` data from a drag & drop event can only be accessed during the `dragStart` and `drop` parts of it in Chrome (and therefore the app). We were using this data to highlight the sort slots on the Inventory and Crew tabs, and to indicate potential drop locations. This PR fixes that by saving the data as a data transfer type which can be accessed at any part of the process. As a side effect the sort slots and drop locations are not highlighted if the dropped entity comes from a compendium/folder.