### PR TITLE
Vehicle Improvements III

### DIFF
--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -176,6 +176,13 @@ Hooks.on('renderChatLog', (_sidebar: SidebarTab, html: JQuery<HTMLElement>, _dat
 	});
 });
 
+// Currently there is no way to specify the class for rendering a compendium collection application since it is
+// hardcoded. However, we can cheat the system into using our own implementation by manually instanciating it and
+// patching the compendium. Also, because we want to apply this even to newly created compendia we run this on every
+// compendium directory bar rendering (it's triggered right after a new compendium is created). We went with this way
+// of cheating the system in order to maintain compatibility with FVTTv10+ and to capture newly created compendia.
+// For context, we want to perform this patch to allow sheets with drop areas to properly highlight when something is
+// being dragged from a compendium.
 const COMPENDIUM_PATCHING = {
 	PATCHED: new Set<string>(),
 	TYPES: ['Actor', 'Item'],

--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -8,6 +8,7 @@
 
 import { register as registerConfig, ready as readyConfigs } from '@/config';
 import { register as registerCombat } from '@/combat';
+import { register as registerSidebars } from '@/sidebar';
 import { register as registerDice } from '@/dice';
 import { register as registerEnrichers } from '@/enrichers';
 import { register as registerFonts } from '@/fonts';
@@ -97,6 +98,7 @@ Hooks.once('init', async () => {
 
 	// Misc. modules with one-time registrations
 	registerCombat();
+	registerSidebars();
 	registerEnrichers();
 	registerFonts();
 	registerDice();

--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -29,13 +29,10 @@ import { performMigrations } from '@/migrations/MigrationHelper';
 
 import './scss/index.scss';
 
-async function doAlphaNotice() {
+async function doAlphaNotice(lastAlpha: string) {
 	if (!game.user.isGM) {
 		return;
 	}
-
-	// Get the last-acknowledged Alpha version notice.
-	const lastAlpha = game.settings.get(SETTINGS_NAMESPACE, KEY_ALPHA_VERSION) as string;
 
 	const [lastMajor, lastMinor, lastRevision] = lastAlpha.split('.').map((v) => parseInt(v));
 	const [currMajor, currMinor, currRevision] = game.system.version.split('.').map((v) => parseInt(v));
@@ -107,10 +104,13 @@ Hooks.once('init', async () => {
 });
 
 Hooks.once('ready', async () => {
-	await doAlphaNotice();
+	// Get the last-acknowledged Alpha version notice.
+	const lastAlpha = game.settings.get<string>(SETTINGS_NAMESPACE, KEY_ALPHA_VERSION) ?? '0.0.0';
+
+	await doAlphaNotice(lastAlpha);
 	readyConfigs();
 
-	await performMigrations();
+	await performMigrations(lastAlpha);
 
 	registerStoryPointTracker();
 	registerVehicles();

--- a/src/actor/data/VehicleDataModel.ts
+++ b/src/actor/data/VehicleDataModel.ts
@@ -93,16 +93,18 @@ export default abstract class VehicleDataModel extends foundry.abstract.DataMode
 	static readonly _GAME_VEHICLES = new Set<GenesysActor<VehicleDataModel>>();
 
 	static override migrateData(source: any) {
-		const passengers: Array<ActorPointer & { id?: string }> = source.passengers.list;
-		for (const passenger of passengers) {
-			// eslint-disable-next-line no-prototype-builtins
-			if (!passenger.hasOwnProperty('id')) {
-				break;
+		const passengers: Array<ActorPointer & { id?: string }> | undefined = source.passengers?.list;
+		if (passengers) {
+			for (const passenger of passengers) {
+				// eslint-disable-next-line no-prototype-builtins
+				if (!passenger.hasOwnProperty('id')) {
+					break;
+				}
+				// We removed the `id` property and added `uuid`. We transfer the data from one to the other to allow the migration
+				// script that runs after to save the proper data. (See "src\migrations\1-use-uuid-for-vehicle.ts")
+				passenger.uuid = passenger.id!;
+				delete passenger.id;
 			}
-			// We removed the `id` property and added `uuid`. We transfer the data from one to the other to allow the migration
-			// script that runs after to save the proper data. (See "src\migrations\1-use-uuid-for-vehicle.ts")
-			passenger.uuid = passenger.id!;
-			delete passenger.id;
 		}
 
 		return super.migrateData(source);

--- a/src/actor/sheets/AdversarySheet.ts
+++ b/src/actor/sheets/AdversarySheet.ts
@@ -51,9 +51,9 @@ export default class AdversarySheet extends VueSheet(GenesysActorSheet<Adversary
 			return false;
 		}
 
-		// Make sure that the item in question exists.
+		// Make sure that the item in question exists and this actor doesn't own it.
 		const droppedItem = await fromUuid<GenesysItem<BaseItemDataModel>>(dragData.uuid);
-		if (!droppedItem) {
+		if (!droppedItem || droppedItem.actor?.uuid === this.actor.uuid) {
 			return false;
 		}
 

--- a/src/actor/sheets/MinionSheet.ts
+++ b/src/actor/sheets/MinionSheet.ts
@@ -31,9 +31,9 @@ export default class MinionSheet extends AdversarySheet {
 			return false;
 		}
 
-		// Make sure that the item in question exists.
+		// Make sure that the item in question exists and this actor doesn't own it.
 		const droppedItem = await fromUuid<GenesysItem<BaseItemDataModel>>(dragData.uuid);
-		if (!droppedItem) {
+		if (!droppedItem || droppedItem.actor?.uuid === this.actor.uuid) {
 			return false;
 		}
 

--- a/src/actor/sheets/VehicleSheet.ts
+++ b/src/actor/sheets/VehicleSheet.ts
@@ -45,9 +45,9 @@ export default class VehicleSheet extends VueSheet(GenesysActorSheet<VehicleData
 			return false;
 		}
 
-		// Make sure that the item in question exists.
+		// Make sure that the item in question exists and this actor doesn't own it.
 		const droppedItem = await fromUuid<GenesysItem<BaseItemDataModel>>(dragData.uuid);
-		if (!droppedItem) {
+		if (!droppedItem || droppedItem.actor?.uuid === this.actor.uuid) {
 			return false;
 		}
 
@@ -58,17 +58,12 @@ export default class VehicleSheet extends VueSheet(GenesysActorSheet<VehicleData
 
 		let clonedDroppedItem: GenesysItem<BaseItemDataModel>[] | undefined | boolean;
 		if (VehicleDataModel.isRelevantTypeForContext('INVENTORY', droppedItem.type)) {
-			const sourceActor = droppedItem.actor;
-
-			if (sourceActor && sourceActor.uuid !== this.actor.uuid) {
+			if (droppedItem.actor) {
 				// If the item was dropped from another actor then we try transfering it and save a reference to it.
 				clonedDroppedItem = await transferInventoryBetweenActors(dragData, this.actor, (type) => VehicleDataModel.isRelevantTypeForContext('INVENTORY', type));
-			} else if (!sourceActor) {
+			} else {
 				// If the item comes from a folder or compendium then let `super` handle the drop and save a reference to it.
 				clonedDroppedItem = await super._onDropItem(event, data);
-			} else {
-				// Ignore dropped items if they are already on this actor; they should be handled by specific components on the sheet.
-				return false;
 			}
 
 			// If we sucessfully cloned the dropped inventory item then update the state for any associated effect.

--- a/src/app/AwardXPPrompt.ts
+++ b/src/app/AwardXPPrompt.ts
@@ -39,6 +39,7 @@ export default class AwardXPPrompt extends VueSheet(Application) {
 			...super.defaultOptions,
 			classes: ['app-award-xp-prompt'],
 			width: 400,
+			title: game.i18n.localize('Genesys.Labels.AwardPromptTitle'),
 		};
 	}
 

--- a/src/app/AwardXPPrompt.ts
+++ b/src/app/AwardXPPrompt.ts
@@ -39,7 +39,7 @@ export default class AwardXPPrompt extends VueSheet(Application) {
 			...super.defaultOptions,
 			classes: ['app-award-xp-prompt'],
 			width: 400,
-			title: game.i18n.localize('Genesys.Labels.AwardPromptTitle'),
+			title: game.i18n.localize('Genesys.RewardsPrompt.Title'),
 		};
 	}
 

--- a/src/app/CareerSkillPrompt.ts
+++ b/src/app/CareerSkillPrompt.ts
@@ -27,6 +27,7 @@ export default class CareerSkillPrompt extends VueSheet(Application) {
 			...super.defaultOptions,
 			classes: ['app-career-skill-prompt'],
 			width: 400,
+			title: game.i18n.localize('Genesys.CareerSkillPrompt.Title'),
 		};
 	}
 

--- a/src/app/CloneActorPrompt.ts
+++ b/src/app/CloneActorPrompt.ts
@@ -1,0 +1,60 @@
+import { ContextBase } from '@/vue/SheetContext';
+import VueSheet from '@/vue/VueSheet';
+import VueCloneActorPrompt from '@/vue/apps/CloneActorPrompt.vue';
+
+import GenesysActor from '@/actor/GenesysActor';
+
+export interface CloneActorPromptContext extends ContextBase {
+	targetActor: GenesysActor;
+	resolvePromise: (targetActor?: GenesysActor) => void;
+}
+
+export default class CloneActorPrompt extends VueSheet(Application) {
+	override get vueComponent() {
+		return VueCloneActorPrompt;
+	}
+
+	static override get defaultOptions() {
+		return {
+			...super.defaultOptions,
+			classes: ['app-clone-actor-prompt'],
+			width: 100,
+			title: game.i18n.localize('Genesys.CloneActorPrompt.Title'),
+		};
+	}
+
+	static async promptForInstantiation(targetActor: GenesysActor) {
+		const sheet = new CloneActorPrompt(targetActor);
+		await sheet.render(true);
+
+		return new Promise<GenesysActor | undefined>((resolve) => {
+			sheet.#resolvePromise = resolve;
+		});
+	}
+
+	readonly targetActor: GenesysActor;
+	#resolvePromise?: (targetActor?: GenesysActor) => void;
+
+	constructor(targetActor: GenesysActor) {
+		super();
+
+		this.targetActor = targetActor;
+	}
+
+	override async getVueContext(): Promise<CloneActorPromptContext> {
+		return {
+			targetActor: this.targetActor,
+			resolvePromise: async (targetActor) => {
+				this.#resolvePromise?.(targetActor);
+				this.#resolvePromise = undefined;
+
+				await this.close();
+			},
+		};
+	}
+
+	override async close(options = {}) {
+		this.#resolvePromise?.();
+		await super.close(options);
+	}
+}

--- a/src/app/DicePrompt.ts
+++ b/src/app/DicePrompt.ts
@@ -60,6 +60,7 @@ export default class DicePrompt extends VueSheet(Application) {
 			...super.defaultOptions,
 			classes: ['app-dice-prompt'],
 			width: 500,
+			title: game.i18n.localize('Genesys.DicePrompt.Title'),
 		};
 	}
 

--- a/src/app/SelectCharacterSkillPrompt.ts
+++ b/src/app/SelectCharacterSkillPrompt.ts
@@ -26,6 +26,7 @@ export default class SelectCharacterSkillPrompt extends VueSheet(Application) {
 			...super.defaultOptions,
 			classes: ['app-select-character-skill-prompt'],
 			width: 100,
+			title: game.i18n.localize('Genesys.Labels.CharacterSkillPromptTitle'),
 		};
 	}
 

--- a/src/app/SelectCharacterSkillPrompt.ts
+++ b/src/app/SelectCharacterSkillPrompt.ts
@@ -26,7 +26,7 @@ export default class SelectCharacterSkillPrompt extends VueSheet(Application) {
 			...super.defaultOptions,
 			classes: ['app-select-character-skill-prompt'],
 			width: 100,
-			title: game.i18n.localize('Genesys.Labels.CharacterSkillPromptTitle'),
+			title: game.i18n.localize('Genesys.CharacterSkillPrompt.Title'),
 		};
 	}
 

--- a/src/data/DragTransferData.ts
+++ b/src/data/DragTransferData.ts
@@ -1,5 +1,5 @@
 export type DragTransferData = {
-	uuid: string;
+	uuid?: string;
 	type?: string;
 	genesysType?: string;
 };

--- a/src/data/DragTransferData.ts
+++ b/src/data/DragTransferData.ts
@@ -32,7 +32,7 @@ function decodeUpperCase(text: string) {
 	return text.replace(ENCODED_UPPER_CASE_PATTERN, (_match, group1: string) => String.fromCodePoint(parseInt(group1, 10)));
 }
 
-export function constructDragTransferTypeFromData(genesysType: string, uuid: ItemUUID | ActorUUID | TokenDocumentUUID) {
+export function constructDragTransferTypeFromData(genesysType: string, uuid: DocumentUUID) {
 	return `${GENESYS_DRAG_TYPE_PREFIX}/${encodeUpperCase(genesysType)}/${encodeUpperCase(uuid)}`;
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -13,9 +13,20 @@ import GenesysCombat from '@/combat/GenesysCombat';
 import GenesysCombatant from '@/combat/GenesysCombatant';
 import GenesysCombatTracker from '@/combat/GenesysCombatTracker';
 import { GENESYS_CONFIG } from '@/config';
+import GenesysActorDirectory from '@/sidebar/GenesysActorDirectory';
+import GenesysItemDirectory from '@/sidebar/GenesysItemDirectory';
 
 declare global {
-	const ui: FoundryUI<GenesysActor, ActorDirectory<GenesysActor>, GenesysItem, ChatMessage<GenesysActor>, ChatLog<ChatMessage<GenesysActor>>, CompendiumDirectory, GenesysCombatTracker<GenesysCombat>>;
+	const ui: FoundryUI<
+		GenesysActor,
+		GenesysActorDirectory<GenesysActor>,
+		GenesysItem,
+		GenesysItemDirectory<GenesysItem>,
+		ChatMessage<GenesysActor>,
+		ChatLog<ChatMessage<GenesysActor>>,
+		CompendiumDirectory,
+		GenesysCombatTracker<GenesysCombat>
+	>;
 	const canvas: Canvas;
 
 	interface GenesysConfig
@@ -23,7 +34,7 @@ declare global {
 			AmbientLightDocument,
 			GenesysEffect,
 			GenesysActor,
-			ActorDirectory<GenesysActor>,
+			GenesysActorDirectory<GenesysActor>,
 			ChatLog,
 			ChatMessage,
 			GenesysCombat,
@@ -32,6 +43,7 @@ declare global {
 			CompendiumDirectory,
 			Hotbar,
 			GenesysItem,
+			GenesysItemDirectory<GenesysItem>,
 			Macro,
 			MeasuredTemplateDocument,
 			TileDocument,

--- a/src/migrations/1-use-uuid-for-vehicle.ts
+++ b/src/migrations/1-use-uuid-for-vehicle.ts
@@ -1,94 +1,84 @@
 import GenesysActor from '@/actor/GenesysActor';
 import VehicleDataModel from '@/actor/data/VehicleDataModel';
-import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
-import { KEY_MIGRATION_VERSION } from '@/settings/alpha';
+import { MigrationStatus } from '@/migrations/MigrationHelper';
 
+/**
+ * Migration script for vehicles that are using an actor's id instead of the actor's uuid. The former is not completly unique
+ * and limits the type of actors it can refer to.
+ */
 export async function migrate_UseUuidForVehicles() {
-	const migrationVersion = game.settings.get<number>(SETTINGS_NAMESPACE, KEY_MIGRATION_VERSION) ?? 0;
-
-	if (migrationVersion === 0) {
-		const isGmHub = game.users.activeGM?.isSelf ?? (game.user.isGM && game.users.filter((user) => user.isGM && user.active).every((candidate) => candidate.id >= game.user.id));
-		if (!isGmHub) {
-			ui.notifications.warn('MIGRATION NEEDED: A migration related to the vehicles data is needed. Please wait for a GM to perform it before using the system.', { permanent: true });
-			return;
-		}
-
-		ui.notifications.warn('MIGRATION STARTED: Migrating data related to vehicles; please be patient and do not close the application.', { permanent: true });
-
-		// Get all the vehicles on the world and compendiums.
-		const vehiclesInWorld = game.actors.filter<GenesysActor<VehicleDataModel>>((actor) => actor.type === 'vehicle');
-		const vehiclesInCompendium = await Promise.all(
-			game.packs.reduce(
-				(accum, pack) => {
-					if (pack.metadata.type === 'Actor') {
-						pack.index.forEach((compendiumIndex) => {
-							if (compendiumIndex.type === 'vehicle') {
-								accum.push(pack.getDocument(compendiumIndex._id) as Promise<GenesysActor<VehicleDataModel>>);
-							}
-						});
-					}
-					return accum;
-				},
-				[] as Promise<GenesysActor<VehicleDataModel>>[],
-			),
-		);
-		const vehicles = vehiclesInWorld.concat(vehiclesInCompendium);
-
-		for (const vehicle of vehicles) {
-			const updateMap = new Map<string, any>();
-			const passengersList = vehicle.systemData.passengers.list;
-
-			// If the vehicle has passangers on them then we need to update their references from id's to UUID's.
-			if (passengersList.length > 0) {
-				const passengers: typeof passengersList = [];
-
-				for (const passenger of passengersList) {
-					const passengerActor = game.actors.get(passenger.uuid);
-
-					if (passengerActor) {
-						passengers.push({
-							uuid: passengerActor.uuid,
-							sort: passenger.sort,
-						});
-					}
-				}
-
-				updateMap.set('system.passengers.list', passengers);
-			}
-
-			let updateRoles = false;
-			const roles = [...vehicle.systemData.roles];
-			for (const role of roles) {
-				const roleMembers = role.members;
-
-				// If the role has any members then we need to update their references from id's to UUID's.
-				if (roleMembers.length > 0) {
-					const members: string[] = [];
-
-					for (const member of roleMembers) {
-						const memberActor = game.actors.get(member);
-
-						if (memberActor) {
-							members.push(memberActor.uuid);
+	// Get all the vehicles on the world and compendiums.
+	const vehiclesInWorld = game.actors.filter<GenesysActor<VehicleDataModel>>((actor) => actor.type === 'vehicle');
+	const vehiclesInCompendium = await Promise.all(
+		game.packs.reduce(
+			(accum, pack) => {
+				if (pack.metadata.type === 'Actor') {
+					pack.index.forEach((compendiumIndex) => {
+						if (compendiumIndex.type === 'vehicle') {
+							accum.push(pack.getDocument(compendiumIndex._id) as Promise<GenesysActor<VehicleDataModel>>);
 						}
-					}
+					});
+				}
+				return accum;
+			},
+			[] as Promise<GenesysActor<VehicleDataModel>>[],
+		),
+	);
+	const vehicles = vehiclesInWorld.concat(vehiclesInCompendium);
 
-					role.members = members;
-					updateRoles = true;
+	for (const vehicle of vehicles) {
+		const updateMap = new Map<string, any>();
+		const passengersList = vehicle.systemData.passengers.list;
+
+		// If the vehicle has passangers on them then we need to update their references from id's to UUID's.
+		if (passengersList.length > 0) {
+			const passengers: typeof passengersList = [];
+
+			for (const passenger of passengersList) {
+				const passengerActor = game.actors.get(passenger.uuid);
+
+				if (passengerActor) {
+					passengers.push({
+						uuid: passengerActor.uuid,
+						sort: passenger.sort,
+					});
 				}
 			}
 
-			// Update the roles array if at least one of them had to be updated.
-			if (updateRoles) {
-				updateMap.set('system.roles', roles);
-			}
+			updateMap.set('system.passengers.list', passengers);
+		}
 
-			if (updateMap.size > 0) {
-				await vehicle.update(Object.fromEntries(updateMap));
+		let updateRoles = false;
+		const roles = [...vehicle.systemData.roles];
+		for (const role of roles) {
+			const roleMembers = role.members;
+
+			// If the role has any members then we need to update their references from id's to UUID's.
+			if (roleMembers.length > 0) {
+				const members: string[] = [];
+
+				for (const member of roleMembers) {
+					const memberActor = game.actors.get(member);
+
+					if (memberActor) {
+						members.push(memberActor.uuid);
+					}
+				}
+
+				role.members = members;
+				updateRoles = true;
 			}
 		}
 
-		ui.notifications.warn('MIGRATION FINISHED: The vehicles data has been migrated, thanks for your patience.', { permanent: true });
-		await game.settings.set(SETTINGS_NAMESPACE, KEY_MIGRATION_VERSION, 1);
+		// Update the roles array if at least one of them had to be updated.
+		if (updateRoles) {
+			updateMap.set('system.roles', roles);
+		}
+
+		if (updateMap.size > 0) {
+			await vehicle.update(Object.fromEntries(updateMap));
+		}
 	}
+
+	return MigrationStatus.SUCCESS;
 }

--- a/src/migrations/2-actors-once-in-vehicle.ts
+++ b/src/migrations/2-actors-once-in-vehicle.ts
@@ -1,0 +1,68 @@
+import GenesysActor from '@/actor/GenesysActor';
+import VehicleDataModel from '@/actor/data/VehicleDataModel';
+import { MigrationStatus } from '@/migrations/MigrationHelper';
+
+/**
+ * Previously we allowed for an actor to be part of more than one role. This script removes any actor that is already part of
+ * a role from any other role on the vehicle.
+ */
+export async function migrate_ActorOnlyOnceInCrew() {
+	// Get all the vehicles on the world and compendiums.
+	const vehiclesInWorld = game.actors.filter<GenesysActor<VehicleDataModel>>((actor) => actor.type === 'vehicle');
+	const vehiclesInCompendium = await Promise.all(
+		game.packs.reduce(
+			(accum, pack) => {
+				if (pack.metadata.type === 'Actor') {
+					pack.index.forEach((compendiumIndex) => {
+						if (compendiumIndex.type === 'vehicle') {
+							accum.push(pack.getDocument(compendiumIndex._id) as Promise<GenesysActor<VehicleDataModel>>);
+						}
+					});
+				}
+				return accum;
+			},
+			[] as Promise<GenesysActor<VehicleDataModel>>[],
+		),
+	);
+	const vehicles = vehiclesInWorld.concat(vehiclesInCompendium);
+
+	for (const vehicle of vehicles) {
+		const crewIds = new Set<string>();
+
+		// Check all the roles first and remove any actor that appears more than once from subsequent roles.
+		const roles = [...vehicle.systemData.roles];
+		let updateRoles = false;
+		for (const role of roles) {
+			for (let k = role.members.length - 1; k >= 0; k--) {
+				if (crewIds.has(role.members[k])) {
+					role.members.splice(k, 1);
+					updateRoles = true;
+				} else {
+					crewIds.add(role.members[k]);
+				}
+			}
+		}
+
+		// Check the passengers and make sure all of them are not in any role.
+		const passengers = [...vehicle.systemData.passengers.list];
+		let updatePassengers = false;
+		for (let k = passengers.length - 1; k >= 0; k--) {
+			if (crewIds.has(passengers[k].uuid)) {
+				passengers.splice(k, 1);
+				updatePassengers = true;
+			} else {
+				crewIds.add(passengers[k].uuid);
+			}
+		}
+
+		// Update the vehicle if we found at least one actor repeated.
+		if (updateRoles || updatePassengers) {
+			await vehicle.update({
+				...(updateRoles && { 'system.roles': roles }),
+				...(updatePassengers && { 'system.passengers.list': passengers }),
+			});
+		}
+	}
+
+	return MigrationStatus.SUCCESS;
+}

--- a/src/migrations/MigrationHelper.ts
+++ b/src/migrations/MigrationHelper.ts
@@ -1,0 +1,62 @@
+import { NAMESPACE } from '@/settings';
+import { KEY_MIGRATION_VERSION } from '@/settings/alpha';
+import { migrate_UseUuidForVehicles } from '@/migrations/1-use-uuid-for-vehicle';
+import { migrate_ActorOnlyOnceInCrew } from '@/migrations/2-actors-once-in-vehicle';
+
+export const enum MigrationStatus {
+	SUCCESS,
+	FAILURE,
+}
+
+const migrationScripts: Array<(migrationId: number) => Promise<MigrationStatus>> = [migrate_UseUuidForVehicles, migrate_ActorOnlyOnceInCrew];
+
+export async function performMigrations() {
+	const currentMigrationVersion = game.settings.get<number>(NAMESPACE, KEY_MIGRATION_VERSION) ?? 0;
+	const totalMigrationScripts = migrationScripts.length;
+	if (currentMigrationVersion === totalMigrationScripts) {
+		return;
+	}
+
+	const isGmHub = game.users.activeGM?.isSelf ?? (game.user.isGM && game.users.filter((user) => user.isGM && user.active).every((candidate) => candidate.id >= game.user.id));
+	if (!isGmHub) {
+		ui.notifications.error('Genesys.Migration.MustPerformMigration', { localize: true, permanent: true });
+		return;
+	}
+
+	let lastMigrationRun = currentMigrationVersion;
+	ui.notifications.warn(game.i18n.format('Genesys.Migration.StartingMigration', { amount: totalMigrationScripts - lastMigrationRun }), { permanent: true });
+
+	for (; lastMigrationRun < totalMigrationScripts; lastMigrationRun++) {
+		const migrationId = lastMigrationRun + 1;
+		ui.notifications.warn(game.i18n.format('Genesys.Migration.StartingScriptMigration', { id: migrationId }), { permanent: true });
+
+		let migrationScriptResponse: MigrationStatus;
+		try {
+			migrationScriptResponse = await migrationScripts[lastMigrationRun](migrationId);
+		} catch (error) {
+			migrationScriptResponse = MigrationStatus.FAILURE;
+			console.error(error);
+		}
+
+		if (migrationScriptResponse === MigrationStatus.FAILURE) {
+			ui.notifications.error(game.i18n.format('Genesys.Migration.StoppedScriptMigration', { id: migrationId }), { permanent: true });
+			break;
+		}
+
+		ui.notifications.warn(game.i18n.format('Genesys.Migration.CompletedScriptMigration', { id: migrationId }), { permanent: true });
+	}
+
+	const runAmountMigrations = lastMigrationRun - currentMigrationVersion;
+	if (runAmountMigrations > 0) {
+		await game.settings.set(NAMESPACE, KEY_MIGRATION_VERSION, lastMigrationRun);
+		ui.notifications.info('Genesys.Migration.MultipleSuccessfulMigration', { localize: true, permanent: true });
+		migrationScripts.splice(0, runAmountMigrations);
+	}
+
+	const remainingAmountMigrations = totalMigrationScripts - lastMigrationRun;
+	if (remainingAmountMigrations > 0) {
+		ui.notifications.error(game.i18n.format('Genesys.Migration.StoppedMigration', { amount: remainingAmountMigrations }), { permanent: true });
+	} else {
+		ui.notifications.info('Genesys.Migration.CompletedMigration', { localize: true, permanent: true });
+	}
+}

--- a/src/settings/alpha.ts
+++ b/src/settings/alpha.ts
@@ -13,7 +13,7 @@ export function register(namespace: string) {
 	game.settings.register(namespace, KEY_MIGRATION_VERSION, {
 		name: 'Migration Version',
 		config: false,
-		default: 2,
+		default: 0,
 		type: Number,
 		scope: 'world',
 	});

--- a/src/settings/alpha.ts
+++ b/src/settings/alpha.ts
@@ -13,7 +13,7 @@ export function register(namespace: string) {
 	game.settings.register(namespace, KEY_MIGRATION_VERSION, {
 		name: 'Migration Version',
 		config: false,
-		default: 0,
+		default: 2,
 		type: Number,
 		scope: 'world',
 	});

--- a/src/sidebar/GenesysActorDirectory.ts
+++ b/src/sidebar/GenesysActorDirectory.ts
@@ -1,0 +1,17 @@
+import GenesysActor from '@/actor/GenesysActor';
+import { DragTransferData, constructDragTransferTypeFromData } from '@/data/DragTransferData';
+
+export default class GenesysActorDirectory extends ActorDirectory<GenesysActor> {
+	protected override _onDragStart(event: ElementDragEvent): void {
+		super._onDragStart(event);
+
+		const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
+		if (dragData.type === 'Actor' && dragData.uuid) {
+			const draggedActor = fromUuidSync(dragData.uuid) as { type: string } | null;
+			if (draggedActor) {
+				const genesysTransferType = constructDragTransferTypeFromData(draggedActor.type, dragData.uuid as ActorUUID);
+				event.dataTransfer?.setData(genesysTransferType, '');
+			}
+		}
+	}
+}

--- a/src/sidebar/GenesysCompendium.ts
+++ b/src/sidebar/GenesysCompendium.ts
@@ -5,7 +5,7 @@ export default class GenesysCompendium extends Compendium {
 		super._onDragStart(event);
 
 		const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
-		if (dragData.uuid) {
+		if ((dragData.type === 'Actor' || dragData.type === 'Item') && dragData.uuid) {
 			const draggedEntity = fromUuidSync(dragData.uuid) as { type: string } | null;
 			if (draggedEntity) {
 				const genesysTransferType = constructDragTransferTypeFromData(draggedEntity.type, dragData.uuid as ItemUUID | ActorUUID);

--- a/src/sidebar/GenesysCompendium.ts
+++ b/src/sidebar/GenesysCompendium.ts
@@ -1,0 +1,16 @@
+import { DragTransferData, constructDragTransferTypeFromData } from '@/data/DragTransferData';
+
+export default class GenesysCompendium extends Compendium {
+	protected override _onDragStart(event: ElementDragEvent): void {
+		super._onDragStart(event);
+
+		const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
+		if (dragData.uuid) {
+			const draggedEntity = fromUuidSync(dragData.uuid) as { type: string } | null;
+			if (draggedEntity) {
+				const genesysTransferType = constructDragTransferTypeFromData(draggedEntity.type, dragData.uuid as ItemUUID | ActorUUID);
+				event.dataTransfer?.setData(genesysTransferType, '');
+			}
+		}
+	}
+}

--- a/src/sidebar/GenesysItemDirectory.ts
+++ b/src/sidebar/GenesysItemDirectory.ts
@@ -1,0 +1,17 @@
+import GenesysItem from '@/item/GenesysItem';
+import { DragTransferData, constructDragTransferTypeFromData } from '@/data/DragTransferData';
+
+export default class GenesysItemDirectory extends ItemDirectory<GenesysItem> {
+	protected override _onDragStart(event: ElementDragEvent): void {
+		super._onDragStart(event);
+
+		const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
+		if (dragData.type === 'Item' && dragData.uuid) {
+			const draggedItem = fromUuidSync(dragData.uuid) as { type: string } | null;
+			if (draggedItem) {
+				const genesysTransferType = constructDragTransferTypeFromData(draggedItem.type, dragData.uuid as ItemUUID);
+				event.dataTransfer?.setData(genesysTransferType, '');
+			}
+		}
+	}
+}

--- a/src/sidebar/index.ts
+++ b/src/sidebar/index.ts
@@ -1,0 +1,7 @@
+import GenesysActorDirectory from '@/sidebar/GenesysActorDirectory';
+import GenesysItemDirectory from '@/sidebar/GenesysItemDirectory';
+
+export function register() {
+	CONFIG.ui.actors = GenesysActorDirectory;
+	CONFIG.ui.items = GenesysItemDirectory;
+}

--- a/src/vue/apps/AwardXPPrompt.vue
+++ b/src/vue/apps/AwardXPPrompt.vue
@@ -23,12 +23,12 @@ function awardXP(event: Event) {
 <template>
 	<div class="genesys award-xp-prompt">
 		<div class="amount">
-			<label><Localized label="Genesys.Labels.Amount" /></label>
+			<label><Localized label="Genesys.RewardsPrompt.Amount" /></label>
 			<input type="number" min="0" v-model="amount" />
 		</div>
 
 		<div class="reason">
-			<label><Localized label="Genesys.Labels.Reason" /></label>
+			<label><Localized label="Genesys.RewardsPrompt.Reason" /></label>
 			<textarea v-model="reason"></textarea>
 		</div>
 

--- a/src/vue/apps/CareerSkillPrompt.vue
+++ b/src/vue/apps/CareerSkillPrompt.vue
@@ -32,8 +32,6 @@ function confirm(event: Event) {
 
 <template>
 	<div class="genesys career-skill-prompt">
-		<header><Localized label="Genesys.CareerSkillPrompt.Header" /></header>
-
 		<div class="career-skills-hint"><Localized label="Genesys.CareerSkillPrompt.Hint" /></div>
 
 		<div class="selections">
@@ -75,12 +73,6 @@ function confirm(event: Event) {
 
 	button {
 		font-family: 'Roboto Serif', serif;
-	}
-
-	header {
-		font-family: 'Bebas Neue', sans-serif;
-		color: colors.$blue;
-		font-size: 2em;
 	}
 
 	.career-skills-hint {

--- a/src/vue/apps/CloneActorPrompt.vue
+++ b/src/vue/apps/CloneActorPrompt.vue
@@ -1,0 +1,127 @@
+<script lang="ts" setup>
+import { inject, ref, toRaw } from 'vue';
+import { CloneActorPromptContext } from '@/app/CloneActorPrompt';
+import { RootContext } from '@/vue/SheetContext';
+import Localized from '@/vue/components/Localized.vue';
+import GenesysActor from '@/actor/GenesysActor';
+
+type InstantiationMethod = 'Original' | 'Clone';
+
+const context = inject<CloneActorPromptContext>(RootContext)!;
+const actorName = ref(context.targetActor.name);
+const instantiationMethod = ref<InstantiationMethod>('Original');
+
+async function submitSelection(event: Event) {
+	event.preventDefault();
+	let targetActor: GenesysActor | undefined = toRaw(context.targetActor);
+
+	if (instantiationMethod.value === 'Clone') {
+		const modifiedProperties = {
+			name: actorName.value ? actorName.value : targetActor.name,
+			flags: {
+				...targetActor.flags,
+				...(targetActor.type === 'minion' && { genesys: { independentMinion: true } }),
+			},
+		};
+		targetActor = await (Actor.implementation as typeof GenesysActor).create(foundry.utils.mergeObject(targetActor.toObject(), modifiedProperties));
+
+		await targetActor?.update({ 'prototypeToken.actorLink': true });
+	}
+
+	context.resolvePromise(targetActor);
+}
+</script>
+
+<template>
+	<div class="genesys clone-actor-prompt">
+		<div class="instantiation-method">
+			<div class="instantiation-method-choice">
+				<input type="radio" id="clone-actor-prompt-method-original" value="Original" v-model="instantiationMethod" />
+				<label for="clone-actor-prompt-method-original"><Localized label="Genesys.CloneActorPrompt.OriginalMethod.Label" /></label>
+			</div>
+
+			<div class="instantiation-method-choice">
+				<input type="radio" id="clone-actor-prompt-method-clone" value="Clone" v-model="instantiationMethod" />
+				<label for="clone-actor-prompt-method-clone"><Localized label="Genesys.CloneActorPrompt.CloneMethod.Label" /></label>
+			</div>
+		</div>
+		<div class="instantiation-description">
+			<Localized :label="`Genesys.CloneActorPrompt.${instantiationMethod}Method.Description`" />
+		</div>
+		<div :class="{ 'clone-name': true, hidden: instantiationMethod !== 'Clone' }">
+			<label><Localized label="Genesys.CloneActorPrompt.CloneMethod.ActorNameLabel" /></label>
+			<input type="text" v-model="actorName" />
+		</div>
+
+		<button class="submit-button" @click="submitSelection"><Localized label="Genesys.Labels.Select" /></button>
+	</div>
+</template>
+
+<style lang="scss">
+@use '@scss/mixins/backgrounds.scss';
+
+.app-clone-actor-prompt {
+	min-width: 28rem;
+	min-height: 15rem;
+
+	.window-content {
+		@include backgrounds.crossboxes();
+	}
+}
+</style>
+
+<style lang="scss" scoped>
+@use '@scss/vars/colors.scss';
+
+.clone-actor-prompt {
+	.instantiation-method {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.3em;
+		text-align: center;
+		padding: 0.3em;
+		font-family: 'Roboto Serif', serif;
+		font-size: 1.15em;
+
+		.instantiation-method-choice {
+			input {
+				vertical-align: top;
+			}
+			label {
+				padding-left: 0.5rem;
+			}
+		}
+	}
+
+	.instantiation-description {
+		font-family: 'Roboto', serif;
+		font-size: 0.9rem;
+		padding: 0.1rem;
+		min-height: 4rem;
+		text-align: justify;
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.clone-name {
+		display: grid;
+		grid-template-columns: auto 1rem 1fr;
+		gap: 0.3em;
+		align-items: center;
+
+		&.hidden {
+			visibility: hidden;
+		}
+
+		input {
+			grid-column: 3 / span 1;
+		}
+	}
+
+	.submit-button {
+		float: right;
+		margin-top: 1rem;
+		width: 50%;
+	}
+}
+</style>

--- a/src/vue/apps/DicePrompt.vue
+++ b/src/vue/apps/DicePrompt.vue
@@ -516,6 +516,7 @@ async function approximateProbability() {
 		<div v-if="USE_CHANCE_TO_SUCCEED" class="chance-to-succeed">
 			<label>
 				<i class="fas fa-circle-info" :data-tooltip="`Genesys.DicePrompt.ChanceToSucceedBy${USE_CHANCE_TO_SUCCEED_BY_PERMUTATION ? 'Permutation' : 'Simulation'}Disclaimer`"></i>
+				{{ '\xa0' }}
 				<Localized label="Genesys.DicePrompt.ChanceToSucceed" />
 			</label>
 
@@ -528,10 +529,8 @@ async function approximateProbability() {
 	</div>
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @use '@scss/mixins/backgrounds.scss';
-@use '@scss/vars/colors.scss';
-@use '@scss/vars/sheet.scss';
 
 .app-dice-prompt {
 	min-width: 500px;
@@ -541,6 +540,11 @@ async function approximateProbability() {
 		@include backgrounds.crossboxes();
 	}
 }
+</style>
+
+<style lang="scss" scoped>
+@use '@scss/vars/colors.scss';
+@use '@scss/vars/sheet.scss';
 
 .dice-prompt {
 	display: grid;
@@ -558,8 +562,8 @@ async function approximateProbability() {
 
 		.hint {
 			font-family: 'Roboto', serif;
-			font-size: 0.8rem;
-			color: colors.$dark-blue;
+			font-size: 1rem;
+			// color: colors.$dark-blue;
 		}
 	}
 

--- a/src/vue/apps/DicePrompt.vue
+++ b/src/vue/apps/DicePrompt.vue
@@ -443,7 +443,6 @@ async function approximateProbability() {
 	<div class="genesys dice-prompt">
 		<!-- Header Text -->
 		<header>
-			<span><Localized label="Genesys.DicePrompt.Title" /></span>
 			<span class="hint"><Localized label="Genesys.DicePrompt.Hint" /></span>
 		</header>
 

--- a/src/vue/apps/SelectCharacterSkillPrompt.vue
+++ b/src/vue/apps/SelectCharacterSkillPrompt.vue
@@ -105,7 +105,7 @@ function submitSelection(event: Event) {
 			width: 1.5em;
 			height: 1.5em;
 			font-size: 1rem;
-            line-height: 1.5em;
+			line-height: 1.5em;
 		}
 	}
 

--- a/src/vue/apps/SelectCharacterSkillPrompt.vue
+++ b/src/vue/apps/SelectCharacterSkillPrompt.vue
@@ -55,7 +55,6 @@ function submitSelection(event: Event) {
 
 <style lang="scss">
 @use '@scss/mixins/backgrounds.scss';
-@use '@scss/vars/colors.scss';
 
 .app-select-character-skill-prompt {
 	min-width: 28rem;
@@ -65,6 +64,10 @@ function submitSelection(event: Event) {
 		@include backgrounds.crossboxes();
 	}
 }
+</style>
+
+<style lang="scss" scoped>
+@use '@scss/vars/colors.scss';
 
 .select-character-skill-prompt {
 	.char-skill-option {
@@ -98,10 +101,11 @@ function submitSelection(event: Event) {
 			border: 1px dashed black;
 			border-radius: 0.75rem;
 			text-align: center;
-			margin: 0.1em 0.1em 0.1em 0.2em;
-			min-width: 1.5rem;
-			height: 1.5rem;
+			margin: 0.1em;
+			width: 1.5em;
+			height: 1.5em;
 			font-size: 1rem;
+            line-height: 1.5em;
 		}
 	}
 

--- a/src/vue/components/ActorTile.vue
+++ b/src/vue/components/ActorTile.vue
@@ -43,13 +43,11 @@ const career = props.actor.type === 'character' ? toRaw(props.actor).items.find(
 onUpdated(() => {
 	const imageDomValue = imageDom.value;
 	if (imageDomValue) {
-		const imageSrc = imageDomValue.getAttribute('src');
-		if (imageSrc !== props.actor.img) {
+		if (imageDomValue.getAttribute('src') !== props.actor.img) {
 			imageDomValue.setAttribute('src', props.actor.img);
 		}
 
-		const imageAlt = imageDomValue.getAttribute('alt');
-		if (imageAlt !== props.actor.name) {
+		if (imageDomValue.getAttribute('alt') !== props.actor.name) {
 			imageDomValue.setAttribute('alt', props.actor.name);
 		}
 	}

--- a/src/vue/components/inventory/InventoryItem.vue
+++ b/src/vue/components/inventory/InventoryItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, inject, ref, toRaw, nextTick } from 'vue';
+import { computed, inject, ref, toRaw } from 'vue';
 import { ActorSheetContext, RootContext } from '@/vue/SheetContext';
 
 import GenesysItem from '@/item/GenesysItem';
@@ -276,11 +276,9 @@ async function changeItemQuantity(event: MouseEvent, item: GenesysItem, value: n
 		});
 	}
 
-	nextTick(() => {
-		if (containerDiv && containerScroll !== undefined) {
-			containerDiv.scrollTop = containerScroll;
-		}
-	});
+	if (containerDiv && containerScroll !== undefined) {
+		containerDiv.scrollTop = containerScroll;
+	}
 }
 
 async function changeDamageState(item: GenesysItem, currentState: EquipmentDamageState, direction: number) {

--- a/src/vue/components/inventory/InventoryItem.vue
+++ b/src/vue/components/inventory/InventoryItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, inject, ref, toRaw } from 'vue';
+import { computed, inject, ref, toRaw, nextTick } from 'vue';
 import { ActorSheetContext, RootContext } from '@/vue/SheetContext';
 
 import GenesysItem from '@/item/GenesysItem';
@@ -264,7 +264,10 @@ function dragLeave() {
 	dragCounter.value = Math.max(0, dragCounter.value - 1);
 }
 
-async function changeItemQuantity(item: GenesysItem, value: number) {
+async function changeItemQuantity(event: MouseEvent, item: GenesysItem, value: number) {
+	const containerDiv = (event.currentTarget as HTMLAnchorElement | null)?.parentElement?.parentElement;
+	const containerScroll = containerDiv?.scrollTop;
+
 	if (value <= 0) {
 		await toRaw(item).delete();
 	} else {
@@ -272,6 +275,12 @@ async function changeItemQuantity(item: GenesysItem, value: number) {
 			'system.quantity': value,
 		});
 	}
+
+	nextTick(() => {
+		if (containerDiv && containerScroll !== undefined) {
+			containerDiv.scrollTop = containerScroll;
+		}
+	});
 }
 
 async function changeDamageState(item: GenesysItem, currentState: EquipmentDamageState, direction: number) {
@@ -320,6 +329,8 @@ async function dropInventoryIntoContainer(event: DragEvent) {
 		if (!droppedItem) {
 			return;
 		}
+	} else if (!sourceActor) {
+		[droppedItem] = (await actor.createEmbeddedDocuments('Item', [droppedItem.toObject()])) as GenesysItem<EquipmentDataModel>[];
 	}
 
 	// Mark the items as being inside the dropped container.
@@ -431,7 +442,13 @@ async function dropInventoryIntoContainer(event: DragEvent) {
 			</div>
 		</div>
 
-		<a class="quantity" @click="changeItemQuantity(item, item.systemData.quantity + 1)" @contextmenu="changeItemQuantity(item, item.systemData.quantity - 1)" v-if="item.type !== 'container'" data-tooltip="Genesys.Labels.Quantity">
+		<a
+			v-if="item.type !== 'container'"
+			class="quantity"
+			@click="changeItemQuantity($event, item, item.systemData.quantity + 1)"
+			@contextmenu="changeItemQuantity($event, item, item.systemData.quantity - 1)"
+			data-tooltip="Genesys.Labels.Quantity"
+		>
 			{{ item.systemData.quantity }}
 			<i class="fas fa-backpack"></i>
 		</a>

--- a/src/vue/components/vehicle/Role.vue
+++ b/src/vue/components/vehicle/Role.vue
@@ -7,6 +7,8 @@ import MenuItem from '@/vue/components/MenuItem.vue';
 import ActorTile from '@/vue/components/ActorTile.vue';
 import GenesysActor from '@/actor/GenesysActor';
 
+type MemberUUID = ActorUUID | TokenDocumentUUID;
+
 const props = withDefaults(
 	defineProps<{
 		id: string;
@@ -27,7 +29,7 @@ const emit = defineEmits<{
 	(e: 'removeMember', memberUuid: string): void;
 	(e: 'actorDragStart', event: DragEvent): void;
 	(e: 'actorDragEnd'): void;
-	(e: 'entityDrop', event: DragEvent): void;
+	(e: 'entityDrop', event: DragEvent, memberUnder?: MemberUUID): void;
 }>();
 
 const dragCounter = ref(0);
@@ -55,10 +57,10 @@ function dragLeave() {
 	dragCounter.value -= 1;
 }
 
-function drop(event: DragEvent) {
+function drop(event: DragEvent, memberUnder?: MemberUUID) {
 	dragCounter.value = 0;
 
-	emit('entityDrop', event);
+	emit('entityDrop', event, memberUnder);
 }
 </script>
 
@@ -72,7 +74,7 @@ function drop(event: DragEvent) {
 		:data-role-id="props.id"
 		@dragenter="dragEnter"
 		@dragleave="dragLeave"
-		@drop="drop"
+		@drop="drop($event)"
 	>
 		<div class="role-data">
 			<div class="role-name">
@@ -101,7 +103,7 @@ function drop(event: DragEvent) {
 
 			<div class="role-members">
 				<TransitionGroup name="mems">
-					<div v-for="member in actorsInRole" :key="member.uuid" class="role-member">
+					<div v-for="member in actorsInRole" :key="member.uuid" class="role-member" @drop="drop($event, member.uuid)">
 						<ActorTile :actor="member as GenesysActor" draggable="true" @dragstart="emit('actorDragStart', $event)" @dragend="emit('actorDragEnd')" :dragging="dragging" @remove-member="emit('removeMember', member.uuid)" />
 					</div>
 				</TransitionGroup>
@@ -110,7 +112,7 @@ function drop(event: DragEvent) {
 	</div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @use '@scss/mixins/reset.scss';
 @use '@scss/vars/colors.scss';
 

--- a/src/vue/sheets/actor/MinionSheet.vue
+++ b/src/vue/sheets/actor/MinionSheet.vue
@@ -18,6 +18,7 @@ const system = computed(() => toRaw(context.data.actor).systemData);
 
 const skills = computed(() => toRaw(context.data.actor).items.filter((i) => i.type === 'skill') as GenesysItem<SkillDataModel>[]);
 
+const isIndependent = actor.value.getFlag<boolean>('genesys', 'independentMinion');
 const editLabel = game.i18n.localize('Genesys.Labels.Edit');
 const deleteLabel = game.i18n.localize('Genesys.Labels.Delete');
 
@@ -38,7 +39,7 @@ async function deleteItem(item: GenesysItem) {
 	<AdversarySheet>
 		<template v-slot:stats>
 			<CombatStat
-				v-if="actor.isToken"
+				v-if="actor.isToken || isIndependent"
 				label="Genesys.Labels.GroupSize"
 				primary-label="Genesys.Adversary.Base"
 				name="system.groupSize"
@@ -55,7 +56,7 @@ async function deleteItem(item: GenesysItem) {
 			<CombatStat label="Genesys.Labels.Soak" name="system.soak" :value="system.soak" edit-primary />
 
 			<CombatStat
-				v-if="actor.isToken"
+				v-if="actor.isToken || isIndependent"
 				label="Genesys.Labels.Wounds"
 				primary-label="Genesys.Labels.Threshold"
 				:value="system.groupWoundThreshold"

--- a/src/vue/sheets/actor/VehicleSheet.vue
+++ b/src/vue/sheets/actor/VehicleSheet.vue
@@ -48,7 +48,7 @@ onBeforeUpdate(updateEffects);
 			<div class="stats-row">
 				<Characteristic label="Genesys.Labels.Silhouette" :value="system.silhouette" name="system.silhouette" can-edit />
 				<Characteristic label="Genesys.Labels.Speed" :value="system.speed" name="system.speed" can-edit />
-				<Characteristic label="Genesys.Labels.Handling" :value="`${system.handling >= 0 ? '+' : ''}${system.handling}`" name="system.handling" can-edit />
+				<Characteristic label="Genesys.Labels.Handling" :value="system.handling.signedString()" name="system.handling" can-edit />
 
 				<div class="stats-column">
 					<CombatStat label="Genesys.Labels.Defense" name="system.defense" :value="system.defense" edit-primary />

--- a/src/vue/sheets/actor/character/InventoryTab.vue
+++ b/src/vue/sheets/actor/character/InventoryTab.vue
@@ -77,6 +77,8 @@ async function dropInventoryToSortSlot(event: DragEvent, sortCategory: Equipment
 		if (!droppedItem) {
 			return;
 		}
+	} else if (!sourceActor) {
+		[droppedItem] = (await actor.createEmbeddedDocuments('Item', [droppedItem.toObject()])) as GenesysItem<EquipmentDataModel>[];
 	}
 
 	// Select the proper inventory category to sort the dropped item among them.

--- a/src/vue/sheets/actor/character/JournalTab.vue
+++ b/src/vue/sheets/actor/character/JournalTab.vue
@@ -146,9 +146,9 @@ async function addXPJournalEntry() {
 			<div class="header"><Localized label="Genesys.Labels.XPJournal" /></div>
 
 			<div class="entries-header">
-				<div><Localized label="Genesys.Labels.Reason" /></div>
+				<div><Localized label="Genesys.RewardsPrompt.Reason" /></div>
 				<div />
-				<div><Localized label="Genesys.Labels.Amount" /></div>
+				<div><Localized label="Genesys.RewardsPrompt.Amount" /></div>
 				<div>
 					<a @click="addXPJournalEntry"><i class="fas fa-plus"></i></a>
 				</div>

--- a/src/vue/sheets/actor/vehicle/CrewTab.vue
+++ b/src/vue/sheets/actor/vehicle/CrewTab.vue
@@ -9,7 +9,7 @@ import SortSlot from '@/vue/components/inventory/SortSlot.vue';
 import ActorTile from '@/vue/components/ActorTile.vue';
 
 import GenesysActor from '@/actor/GenesysActor';
-import { CrewDragTransferData, CrewExtraDragTransferData, extractDataFromDragTransferTypes } from '@/data/DragTransferData';
+import { CrewDragTransferData, CrewExtraDragTransferData, DragTransferData, extractDataFromDragTransferTypes } from '@/data/DragTransferData';
 
 type FromUuidSimpleReturnData = null | {
 	name: string;
@@ -251,14 +251,14 @@ function modifyDragCounters(event: DragEvent, direction: number) {
 }
 
 function dragStart(event: DragEvent, extraData: CrewExtraDragTransferData) {
-	const dragSource = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}');
-	const dragSourceWithExtra: CrewDragTransferData = {
-		...dragSource,
+	const dragData = JSON.parse(event.dataTransfer?.getData('text/plain') ?? '{}') as DragTransferData;
+	const dragDataWithExtra: CrewDragTransferData = {
+		...dragData,
 		...extraData,
 		sourceVehicleUuid: context.data.actor.uuid,
 	};
 
-	event.dataTransfer?.setData('text/plain', JSON.stringify(dragSourceWithExtra));
+	event.dataTransfer?.setData('text/plain', JSON.stringify(dragDataWithExtra));
 }
 
 function dragEnter(event: DragEvent) {

--- a/src/vue/sheets/actor/vehicle/InventoryTab.vue
+++ b/src/vue/sheets/actor/vehicle/InventoryTab.vue
@@ -75,6 +75,8 @@ async function dropInventoryToSortSlot(event: DragEvent, sortCategory: Equipment
 		if (!droppedItem) {
 			return;
 		}
+	} else if (!sourceActor) {
+		[droppedItem] = (await actor.createEmbeddedDocuments('Item', [droppedItem.toObject()])) as GenesysItem<EquipmentDataModel>[];
 	}
 
 	// Select the proper inventory category to sort the dropped item among them.

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -115,11 +115,21 @@ watch(
 				}
 			}
 
-			groupedBySkill.value = groupedBySkillData;
+			groupedBySkill.value = new Map([...groupedBySkillData.entries()].sort(sortNames));
 		}
 	},
 	{ immediate: true },
 );
+
+function sortNames([left]: [string, any], [right]: [string, any]) {
+	if (left > right) {
+		return 1;
+	} else if (left < right) {
+		return -1;
+	} else {
+		return 0;
+	}
+}
 
 async function rollSkillForActor(actor: GenesysActor, skill: GenesysItem<SkillDataModel>) {
 	if (actor.isOwner) {
@@ -138,8 +148,8 @@ async function openActorSheet(actor: GenesysActor) {
 		<div class="grouping-mode">
 			Group By:
 			<select v-model="groupingMode">
-				<option value="member">Member</option>
-				<option value="skill">Skill</option>
+				<option value="member"><Localized label="Genesys.Tabs.Crew" /></option>
+				<option value="skill"><Localized label="Genesys.Labels.Skill" /></option>
 			</select>
 		</div>
 		<div v-if="groupingMode === 'member'" class="members-container">
@@ -369,6 +379,7 @@ async function openActorSheet(actor: GenesysActor) {
 					font-family: 'Bebas Neue', sans-serif;
 					align-items: center;
 					justify-items: center;
+					gap: 0.5em;
 
 					.skill-content-header-charName {
 						grid-column: 1 / span 2;

--- a/types/foundry/client/application/compendium.d.ts
+++ b/types/foundry/client/application/compendium.d.ts
@@ -1,6 +1,6 @@
 /** An interface for displaying the content of a CompendiumCollection. */
-declare class Compendium<TDocument extends CompendiumDocument> extends Application {
-	constructor(collection: CompendiumCollection<TDocument>, options: ApplicationOptions);
+declare class Compendium<TDocument extends CompendiumDocument = CompendiumDocument> extends Application {
+	constructor(collection: CompendiumCollection<TDocument>, options?: ApplicationOptions);
 
 	/** The CompendiumCollection instance which is represented in this Compendium interface. */
 	collection: CompendiumCollection<TDocument>;

--- a/types/foundry/client/config.d.ts
+++ b/types/foundry/client/config.d.ts
@@ -14,6 +14,7 @@ declare global {
 		TCompendiumDirectory extends CompendiumDirectory = CompendiumDirectory,
 		THotbar extends Hotbar = Hotbar,
 		TItem extends Item = Item,
+		TItemDirectory extends ItemDirectory<TItem> = ItemDirectory<TItem>,
 		TMacro extends Macro = Macro,
 		TMeasuredTemplateDocument extends MeasuredTemplateDocument = MeasuredTemplateDocument,
 		TTileDocument extends TileDocument = TileDocument,
@@ -534,7 +535,7 @@ declare global {
 			compendium: ConstructorOf<TCompendiumDirectory>;
 			controls: typeof SceneControls;
 			hotbar: ConstructorOf<THotbar>;
-			items: typeof ItemDirectory;
+			items: ConstructorOf<TItemDirectory>;
 			// journal: typeof JournalDirectory;
 			// macros: typeof MacroDirectory;
 			menu: typeof MainMenu;

--- a/types/foundry/client/documents/actor.d.ts
+++ b/types/foundry/client/documents/actor.d.ts
@@ -34,6 +34,8 @@ declare global {
 		/** Cache the last drawn wildcard token to avoid repeat draws */
 		protected _lastWildcard: string | null;
 
+		flags: Record<string, Record<string, unknown>>;
+
 		/** A convenient reference to the file path of the Actor's profile image */
 		get img(): ImageFilePath;
 

--- a/types/foundry/client/ui/index.d.ts
+++ b/types/foundry/client/ui/index.d.ts
@@ -12,6 +12,7 @@ declare global {
 		TActor extends Actor = Actor,
 		TActorDirectory extends ActorDirectory<TActor> = ActorDirectory<TActor>,
 		TItem extends Item<TActor> = Item<TActor>,
+		TItemDirectory extends ItemDirectory<TItem> = ItemDirectory<TItem>,
 		TChatMessage extends ChatMessage<TActor> = ChatMessage<TActor>,
 		TChatLog extends ChatLog<TChatMessage> = ChatLog<TChatMessage>,
 		TCompendiumDirectory extends CompendiumDirectory = CompendiumDirectory,
@@ -23,7 +24,7 @@ declare global {
 		combat: TCombatTracker;
 		compendium: TCompendiumDirectory;
 		controls: SceneControls;
-		items: ItemDirectory<TItem>;
+		items: TItemDirectory;
 		notifications: Notifications;
 		settings: Settings;
 		tables: RollTableDirectory;

--- a/types/foundry/common/abstract/document.d.ts
+++ b/types/foundry/common/abstract/document.d.ts
@@ -358,7 +358,7 @@ declare global {
 				 * @param key   The flag key
 				 * @return The flag value
 				 */
-				getFlag(scope: string, key: string): unknown;
+				getFlag<FlagType = unknown>(scope: string, key: string): FlagType;
 
 				/**
 				 * Assign a "flag" to this document.

--- a/types/foundry/index.d.ts
+++ b/types/foundry/index.d.ts
@@ -123,3 +123,4 @@ import './common/documents';
 import './common/types';
 import './common/utils';
 import './prosemirror';
+import './util';

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -164,6 +164,19 @@ Genesys:
   CharacterSkillPrompt:
     Title: Select User
 
+  # Clone Actor Prompt Labels
+  CloneActorPrompt:
+    Title: Drop Confirmation
+    OriginalMethod:
+      Label: Reference
+      Description: A reference to the actor will be saved.
+    CloneMethod:
+      Label: Clone
+      Description: >-
+        A clone of the dropped actor will be created and a reference to it will be saved.
+        Additionally, the cloned actor will appear on the 'Actors' directory as a new entry with the name specified below.
+      ActorNameLabel: New Name
+
   # Experience Journal Labels
   XPJournal:
     Award: '<strong>XP Awarded by GM</strong>: {reason}'

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -96,7 +96,7 @@ Genesys:
 
   # Career Skill Prompt
   CareerSkillPrompt:
-    Header: Career Skills
+    Title: Career Skills
     Hint: 'Select Career Skills to gain a rank:'
     RemainingChoices: Remaining Choices
     Confirm: Done
@@ -188,6 +188,21 @@ Genesys:
     InvalidTokenTypeForAction: The selected token is of an invalid type to perform this action.
     EffectsWereNotUpdatedAfterTransfer: There was an error updating the effects with the latest values for the transfered '{name}'.
     NoRoleMembersWithAppropriateSkills: There are no role members that have the appropriate skills to perform this action.
+
+  # Migration Related Messages
+  Migration:
+    MustPerformMigration: >-
+      MIGRATION NEEDED!: Some data needs to be migrated and failure to do so might corrupt the data or break functionality.
+      Please exit out of the world and wait for a GM to perform the migration.
+    StartingMigration: 'MIGRATION STARTED: Commencing {amount} migration(s); please be patient and do not close the application.'
+    StartingScriptMigration: 'MIGRATION STARTED [{id}]: Commencing migration.'
+    StoppedScriptMigration: 'MIGRATION STOPPED [{id}]: Encountered an error while migrating.'
+    CompletedScriptMigration: 'MIGRATION FINISHED [{id}]: Migration completed.'
+    MultipleSuccessfulMigration: 'MIGRATION VERSION UPDATED: At least one migration was completed successfully.'
+    StoppedMigration: >-
+      MIGRATION STOPPED: The migration has stopped due to some errors; consult the console log for what these errors are.
+      There are still {amount} migration(s) that haven't been performed.
+    CompletedMigration: 'MIGRATION FINISHED: All migrations done; thanks for your patience.'
 
   # Story Points
   StoryPoints:
@@ -426,8 +441,11 @@ Genesys:
     EncumbranceCapacity: Encumbrance Capacity
     Information: Information
     Passengers: Passengers
+    Role: Role
     Roles: Roles
     OverCapacity: Over Capacity!
     RoleSkills: Role Skills
     FiringArc: Firing Arc
     Select: Select
+    CharacterSkillPromptTitle: Select User
+    AwardPromptTitle: Rewards

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -454,3 +454,4 @@ Genesys:
     RoleSkills: Role Skills
     FiringArc: Firing Arc
     Select: Select
+    PerformCheck: Perform Check

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -154,6 +154,16 @@ Genesys:
     ChanceToSucceedByPermutationDisclaimer: The displayed probability is exact unless the dice pool includes a super-characteristic.
     ChanceToSucceedBySimulationDisclaimer: The displayed probability is an approximation that uses the Monte Carlo method.
 
+  # Rewards Prompt Labels
+  RewardsPrompt:
+    Title: Rewards
+    Amount: Amount
+    Reason: Reason
+
+  # Character Skill Prompt Labels
+  CharacterSkillPrompt:
+    Title: Select User
+
   # Experience Journal Labels
   XPJournal:
     Award: '<strong>XP Awarded by GM</strong>: {reason}'
@@ -404,9 +414,6 @@ Genesys:
     RankDown: Rank Down
     FreeRankUp: Rank Up (Free)
     FreeRankDown: Rank Down (Free)
-    AwardXP: Award XP
-    Amount: Amount
-    Reason: Reason
     IsRated: Is Rated?
     Qualities: Qualities
     Severity: Severity
@@ -447,5 +454,3 @@ Genesys:
     RoleSkills: Role Skills
     FiringArc: Firing Arc
     Select: Select
-    CharacterSkillPromptTitle: Select User
-    AwardPromptTitle: Rewards

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -96,7 +96,7 @@ Genesys:
 
   # Career Skill Prompt
   CareerSkillPrompt:
-    Header: Compétence de Carrière
+    Title: Compétence de Carrière
     Hint: 'Choissisez une compétence de Carrière pour gagner un rang:'
     RemainingChoices: Autres choix
     Confirm: Réalisé
@@ -154,6 +154,16 @@ Genesys:
     ChanceToSucceedByPermutationDisclaimer: "Affiche la probabilité exacte à moins qu'un dé dans le pool soit une super-caractéristique."
     ChanceToSucceedBySimulationDisclaimer: La probabilité affiché est une approximation caculé à partir de la méthode de Monte Carlo.
 
+  # Rewards Prompt Labels
+  RewardsPrompt:
+    Title: Rewards
+    Amount: Valeur
+    Reason: Raison
+
+  # Character Skill Prompt Labels
+  CharacterSkillPrompt:
+    Title: Select User
+
   # Experience Journal Labels
   XPJournal:
     Award: '<strong>XP attribué par le MJ</strong>: {reason}'
@@ -187,6 +197,21 @@ Genesys:
     InvalidTokenTypeForAction: Le token selectionné est d'un type invalide pour réaliser cette action.
     EffectsWereNotUpdatedAfterTransfer: Une erreur s'est produite lors de la mise à jour des effets avec les dernières données disponibles durant le transfert de '{name}'.
     NoRoleMembersWithAppropriateSkills: Aucun membre du groupe pour ce rôle ne possède les compétences appropriées pour faire cette action.
+
+  # Migration Related Messages
+  Migration:
+    MustPerformMigration: >-
+      MIGRATION NEEDED!: Some data needs to be migrated and failure to do so might corrupt the data or break functionality.
+      Please exit out of the world and wait for a GM to perform the migration.
+    StartingMigration: 'MIGRATION STARTED: Commencing {amount} migration(s); please be patient and do not close the application.'
+    StartingScriptMigration: 'MIGRATION STARTED [{id}]: Commencing migration.'
+    StoppedScriptMigration: 'MIGRATION STOPPED [{id}]: Encountered an error while migrating.'
+    CompletedScriptMigration: 'MIGRATION FINISHED [{id}]: Migration completed.'
+    MultipleSuccessfulMigration: 'MIGRATION VERSION UPDATED: At least one migration was completed successfully.'
+    StoppedMigration: >-
+      MIGRATION STOPPED: The migration has stopped due to some errors; consult the console log for what these errors are.
+      There are still {amount} migration(s) that haven't been performed.
+    CompletedMigration: 'MIGRATION FINISHED: All migrations done; thanks for your patience.'
 
   # Story Points
   StoryPoints:
@@ -388,9 +413,6 @@ Genesys:
     RankDown: Rang Inférieur
     FreeRankUp: Rang Supérieur (Gratuit)
     FreeRankDown: Rang Inférieur (Gratuit)
-    AwardXP: XP obtenus
-    Amount: Valeur
-    Reason: Raison
     IsRated: Est-il mesuré?
     Qualities: Qualitées
     Severity: Sévérité
@@ -425,6 +447,7 @@ Genesys:
     EncumbranceCapacity: Valeur d'emcombrement
     Information: Information
     Passengers: Passagers
+    Role: Rôle
     Roles: Rôles
     OverCapacity: Hors capacité!
     RoleSkills: Compétences lié au rôle

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -453,3 +453,4 @@ Genesys:
     RoleSkills: Compétences lié au rôle
     FiringArc: Arc de tir
     Select: Sélection
+    PerformCheck: Perform Check

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -164,6 +164,19 @@ Genesys:
   CharacterSkillPrompt:
     Title: Select User
 
+  # Clone Actor Prompt Labels
+  CloneActorPrompt:
+    Title: Drop Confirmation
+    OriginalMethod:
+      Label: Reference
+      Description: A reference to the actor will be saved.
+    CloneMethod:
+      Label: Clone
+      Description: >-
+        A clone of the dropped actor will be created and a reference to it will be saved.
+        Additionally, the cloned actor will appear on the 'Actors' directory as a new entry with the name specified below.
+      ActorNameLabel: New Name
+
   # Experience Journal Labels
   XPJournal:
     Award: '<strong>XP attribué par le MJ</strong>: {reason}'


### PR DESCRIPTION
# General Notes
- Most of the commits are "unsafe". What I mean by this is that building at a specific commit, instead of at the last one, might not produce a functional and stable version of the system. The amount of changes is so big that doing each commit incrementally would be a hassle given how I'm working on this.

# Commit 6a6d8c8
- Fixes an error where the migration code for vehicles will try to coerce source data that doesn't exist.

# Commit 6f32d9b
- Highlight drop areas for the Inventory and Crew tabs when dragging from the world.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/fd2b5333-ea16-4238-8b72-d07ba525de29)

# Commit bca76f35fc762ec565ff3721f563f90ef57110c9
- Expands the migration architecture to allow for more than one script to run.
- Add a migration to enforce that an actor appears at most once in a vehicle's Crew tab. This doesn't prevent the actor to also appear in other vehicles.
- There's a new hook defined that is more relevant to a later commit.
- Some miscellaneous localization changes that are more relevant to later commits.

# Commit 4f40783fb1fbcb430cd49efbb454b200298556b6
- Adds titles to "popups" that currently don't have it. For some of them I also removed their header since it was redundant given the new titles.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/eba47664-8406-4c74-aec3-eef9c337c207)

# Commit fbce6a7ca08fba5d214cce57a8bb523874eef7b5
- Allows dropping world and compendium items or actors to be dropped to the dropped areas present on the Inventory and Crew tabs. This applies to characters and vehicles' sheets.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/0954bbaa-bc1f-485c-89ef-8e3baae2729f)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/fd44903c-e9bd-4556-9eb8-c1797c59da70)

# Commit f2097a9db465445028411a37ec07d00c24617f94
- Highlight drops areas when dragging from a compendium.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/e51a4246-09d9-4b20-843f-65844e713c57)

# Commit 58f1be642932f8ea317d5b277cceaf62cba4ecc3
- There is now a dropdown on a vehicle's Skills tab that provides an additional way to group the skills.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/a3413ae1-c58c-4c15-b2ce-30602e62a5f4)

# Commit 094890cbbce86213224bd1352143a9d010bde1b7
- Refactors some localization strings.

# Commit ce8bba0831ed001a4283eb8f23ae578d87fc5346
- Sort the skills for the "Group by Skill" mode.
- Make sure the actor tile (image and alt text) is updated on the Crew tab of a vehicle when said actor is updated.

# Commit f8069f6c900ceafde42066389c6c50b156cb4d6b
- Properly skip migrations for new worlds.

# Commit e49d4916b7242455fa625902cf904f49fd581ee5
- Reorganized some of the top-level `onDrop` code to reject processing items moved around inside the sheet.
- Equipment on adversary sheet can now be dropped onto other actors, folders or compendiums.
  - If the item is dropped into a character/vehicle sheet the item will be removed from the adversary as it's considered a transfer instead of a copy.
- Fixes a bug when increasing an item quantity inside a container with scrollbars. Previously it would scroll to the top instead of retaining the scroll position.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/5a32ea74-c30e-4db4-b864-b53e14aa8560)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/042ed679-024b-4534-8042-0f1f86f8c903)

# Commit 1c46d5d4700bb17a3c45505f5ee1e0f5cdce98af
- Role members can now be sorted on the Crew tab
  - Also, when dropping an actor it takes into account the sort position where you drop it.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/520ad330-1521-4a49-be83-c37ad4bb3757)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/71d1b5aa-afff-46a5-b51d-b026a7b49f5c)

# Commit 660c4128ca290cea533e03671ed51dca86808ad5
- When dropping an actor that can produce unlinked tokens (like minions) a popup will appear to confirm how to save a reference.
  - Either we add a reference to the original actor or we create an clone of the original and add a reference to that.
    - The clone will appear on the 'Actors Directory' and if it's a minion it will show its "final" stats for group size and wound threshold. Specially for wound thresholds there won't be an easy way to edit it during this state so plan accordingly.
- Made the Dice Pool have the crossboxes background like the rest of windows.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/04af72f3-673e-458d-8450-1cb0a7e177f8)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/2d62b1e9-d18a-4bec-8272-6c480f32f5ed)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/4db9c56c-14e6-409e-8d80-04cadf58d020)
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/0f44ba78-58eb-4508-b76a-74f18eef46e8)