### PR TITLE
Confirm inventory deletion upon certain circumstances

### DIFF
--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -212,6 +212,12 @@ Genesys:
     EffectsWereNotUpdatedAfterTransfer: There was an error updating the effects with the latest values for the transfered '{name}'.
     NoRoleMembersWithAppropriateSkills: There are no role members that have the appropriate skills to perform this action.
 
+  # Dialogs Prompts
+  Dialogs:
+    ConfirmDeleteItem:
+      Title: Confirm Removal
+      Content: This will remove the item. Do you want to proceed?
+
   # Migration Related Messages
   Migration:
     MustPerformMigration: >-

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -211,6 +211,12 @@ Genesys:
     EffectsWereNotUpdatedAfterTransfer: Une erreur s'est produite lors de la mise à jour des effets avec les dernières données disponibles durant le transfert de '{name}'.
     NoRoleMembersWithAppropriateSkills: Aucun membre du groupe pour ce rôle ne possède les compétences appropriées pour faire cette action.
 
+  # Dialogs Prompts
+  Dialogs:
+    ConfirmDeleteItem:
+      Title: Confirm Removal
+      Content: This will remove the item. Do you want to proceed?
+
   # Migration Related Messages
   Migration:
     MustPerformMigration: >-


### PR DESCRIPTION
- Shows a confirmation dialog when the user tries to lower an inventory item's quantity to 0.
  - The same confirmation is also shown when lowering an item's damage state past 'Major Damage'
- Fixes a bug when changing an item damage state inside a container with scrollbars. Previously it would scroll to the top instead of retaining the scroll position.

![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/ca31687d-e7dc-4018-b6c6-1240b8cf1607)

Note:
- Implements #141 