### PR TITLE
Adds support for effects that do pool modifications

### DIFF
--- a/public/templates/sheets/effect-config.hbs
+++ b/public/templates/sheets/effect-config.hbs
@@ -112,7 +112,7 @@
 					</div>
 				</div>
 
-				{{#each data.changes as |change i|}}
+				{{#each changes as |change i|}}
 					<div class="row effect-change" data-index="{{i}}">
 						{{#select change.key}}
 							<select name="changes.{{i}}.key">
@@ -159,11 +159,17 @@
 								{{!-- Skill Changes --}}
 
 								{{!-- Dice Pool Changes --}}
+                                <optgroup label="{{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.GroupLabel'}}">
+                                    <option value="genesys.pool.skill">&#x1F9D1; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Skill'}}</option>
+                                </optgroup>
 							</select>
 						{{/select}}
-						<select name="changes.{{i}}.mode" data-dtype="Number">
-							{{selectOptions ../modes selected=change.mode}}
-						</select>
+                        <select name="changes.{{i}}.skill" class="skill-selection {{#if (ne change.key 'genesys.pool.skill')}}hide-it{{/if}}">
+                            {{selectOptions ../skills selected=change.skill sort=true}}
+                        </select>
+                        <select name="changes.{{i}}.mode" data-dtype="Number" class="effect-mode {{#if (eq change.key 'genesys.pool.skill')}}hide-it{{/if}}">
+                            {{selectOptions ../modes selected=change.mode}}
+                        </select>
 						<input type="text" name="changes.{{i}}.value" value="{{change.value}}" />
 						<div class="effect-controls">
 							<a class="effect-control" data-action="delete"><i class="fas fa-trash"></i></a>

--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -180,12 +180,19 @@ Hooks.on('renderChatLog', (_sidebar: SidebarTab, html: JQuery<HTMLElement>, _dat
 
 // Create wiki links in the description section of certain settings. We use a hook here since there is no way to
 // directly add links as any HTML is escaped.
-const wikiLinkPattern = /\[\[([^|\]]+(\|([^\]]+))?)\]\]/g;
+const wikiLinkPattern = /\[\[([^|\]]+)(\|([^\]]+))?\]\]/g;
 Hooks.on('renderSettingsConfig', (_app: SettingsConfig, html: JQuery<HTMLElement>, _data: object) => {
-	const [note] = html.find(`[data-setting-id='genesys.${KEY_DEFAULT_DIFFICULTY}'] > .notes`);
-	note.innerHTML = note.innerHTML.replaceAll(wikiLinkPattern, (_m, g1, _g2, g3) => {
-		return `<a href="https://github.com/Mezryss/FVTT-Genesys/wiki/${g1}" target="_blank">${g3 ? g3 : g1}</a>`;
-	});
+	let [note] = html.find(`[data-setting-id='genesys.${KEY_DEFAULT_DIFFICULTY}'] > .notes`);
+	if (!note) {
+		// FVTT v10 has a different way for structuring their settings.
+		[note] = html.find(`.form-fields:has(input[name='genesys.${KEY_DEFAULT_DIFFICULTY}']) + p.notes`);
+	}
+
+	if (note) {
+		note.innerHTML = note.innerHTML.replaceAll(wikiLinkPattern, (_m, g1, _g2, g3) => {
+			return `<a href="https://github.com/Mezryss/FVTT-Genesys/wiki/${g1}" target="_blank">${g3 ? g3 : g1}</a>`;
+		});
+	}
 });
 
 // Currently there is no way to specify the class for rendering a compendium collection application since it is

--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -15,6 +15,7 @@ import { register as registerFonts } from '@/fonts';
 import { register as registerHandlebarsHelpers } from '@/handlebars';
 import { NAMESPACE as SETTINGS_NAMESPACE, register as registerSettings } from '@/settings';
 import { KEY_ALPHA_VERSION } from '@/settings/alpha';
+import { KEY_DEFAULT_DIFFICULTY } from '@/settings/campaign';
 
 import { register as registerStoryPointTracker } from '@/app/StoryPointTracker';
 import { register as registerActors, AdversaryTypes } from '@/actor';
@@ -126,6 +127,7 @@ function constructOptGroup(select: HTMLSelectElement, groupLabel: string, optVal
 	return optgroup;
 }
 
+// Add options groups to the dialog that appears when creating an actor or item.
 Hooks.on('renderDialog', (_dialog: Dialog, html: JQuery<HTMLElement>, _data: object) => {
 	const container = html[0];
 
@@ -153,6 +155,7 @@ Hooks.on('renderDialog', (_dialog: Dialog, html: JQuery<HTMLElement>, _data: obj
 	}
 });
 
+// Makes the dice icon at the bottom of the chat to function as a shortcut to call the dice prompt.
 Hooks.on('renderChatLog', (_sidebar: SidebarTab, html: JQuery<HTMLElement>, _data: object) => {
 	const diceIcon = html.find('#chat-controls > .chat-control-icon');
 	diceIcon.on('click', async (_event) => {
@@ -172,6 +175,16 @@ Hooks.on('renderChatLog', (_sidebar: SidebarTab, html: JQuery<HTMLElement>, _dat
 		}
 
 		await DicePrompt.promptForRoll(targetActor, '');
+	});
+});
+
+// Create wiki links in the description section of certain settings. We use a hook here since there is no way to
+// directly add links as any HTML is escaped.
+const wikiLinkPattern = /\[\[([^|\]]+(\|([^\]]+))?)\]\]/g;
+Hooks.on('renderSettingsConfig', (_app: SettingsConfig, html: JQuery<HTMLElement>, _data: object) => {
+	const [note] = html.find(`[data-setting-id='genesys.${KEY_DEFAULT_DIFFICULTY}'] > .notes`);
+	note.innerHTML = note.innerHTML.replaceAll(wikiLinkPattern, (_m, g1, _g2, g3) => {
+		return `<a href="https://github.com/Mezryss/FVTT-Genesys/wiki/${g1}" target="_blank">${g3 ? g3 : g1}</a>`;
 	});
 });
 

--- a/src/actor/GenesysActorSheet.ts
+++ b/src/actor/GenesysActorSheet.ts
@@ -39,8 +39,8 @@ export default class GenesysActorSheet<ActorDataModel extends foundry.abstract.D
 				const target = $(event.delegateTarget);
 
 				// Grab the skill name & difficulty
-				const skillName = <string>target.data('skill-check');
-				const difficulty = parseInt(target.data('difficulty'));
+				const skillName: string = target.data('skill-check');
+				const difficulty: string = 'D'.repeat(parseInt(target.data('difficulty')));
 
 				await DicePrompt.promptForRoll(this.actor, skillName, { difficulty });
 			});

--- a/src/app/DicePrompt.ts
+++ b/src/app/DicePrompt.ts
@@ -25,7 +25,7 @@ export interface DicePromptContext extends ContextBase {
 	actor?: GenesysActor;
 	skillName?: string;
 	rollType: RollType;
-	difficulty: number;
+	difficulty: string;
 	rollUnskilled?: Characteristic;
 	rollData: any;
 	app: DicePrompt;
@@ -42,7 +42,7 @@ export type InitiativeRollData = {
 
 type DicePromptOptions = {
 	rollType?: RollType;
-	difficulty?: number;
+	difficulty?: string;
 	rollUnskilled?: Characteristic;
 	rollData?: { [key: string]: any };
 };
@@ -84,7 +84,7 @@ export default class DicePrompt extends VueSheet(Application) {
 	actor?: GenesysActor;
 	skillName?: string;
 	rollType: RollType;
-	difficulty: number;
+	difficulty: string;
 	rollUnskilled?: Characteristic;
 	rollData?: { [key: string]: any };
 
@@ -94,7 +94,7 @@ export default class DicePrompt extends VueSheet(Application) {
 		this.actor = actor;
 		this.skillName = skillName;
 		this.rollType = rollType ?? RollType.Skill;
-		this.difficulty = difficulty ?? 2;
+		this.difficulty = difficulty ?? CONFIG.genesys.settings.defaultDifficulty;
 		this.rollUnskilled = rollUnskilled;
 		this.rollData = rollData;
 	}
@@ -123,12 +123,9 @@ export default class DicePrompt extends VueSheet(Application) {
 export const CALCULATE_CHANCE_WORKER_NAME = 'CalculateChance';
 
 export function registerWorker() {
-	// eslint-disable-next-line
-	if (!!game.workers.get) {
-		if (CONFIG.genesys.settings.showChanceToSucceedFromPermutations) {
-			game.workers.createWorker(CALCULATE_CHANCE_WORKER_NAME, {
-				scripts: ['../systems/genesys/scripts/calculate-chance-worker.js'],
-			});
-		}
+	if (CONFIG.genesys.settings.showChanceToSucceedFromPermutations) {
+		game.workers.createWorker(CALCULATE_CHANCE_WORKER_NAME, {
+			scripts: ['../systems/genesys/scripts/calculate-chance-worker.js'],
+		});
 	}
 }

--- a/src/combat/GenesysCombat.ts
+++ b/src/combat/GenesysCombat.ts
@@ -153,7 +153,7 @@ export default class GenesysCombat extends Combat {
 
 			if (prompt) {
 				try {
-					const promptedRoll = await DicePrompt.promptForInitiative(combatant.actor, skillName, { difficulty: 0 });
+					const promptedRoll = await DicePrompt.promptForInitiative(combatant.actor, skillName, { difficulty: '' });
 
 					roll = promptedRoll.roll;
 					skillName = promptedRoll.skillName;

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@
 import { NAMESPACE as SETTINGS_NAMESPACE } from '@/settings';
 import {
 	KEY_CAREER_SKILL_RANKS,
+	KEY_DEFAULT_DIFFICULTY,
 	KEY_MONEY_NAME,
 	KEY_SHOW_DAMAGE_ON_FAILURE,
 	KEY_SKILLS_COMPENDIUM,
@@ -16,7 +17,7 @@ import {
 	KEY_SUPER_CHARACTERISTICS,
 	KEY_UNCOUPLE_SKILLS_FROM_CHARACTERISTICS,
 } from '@/settings/campaign';
-import { KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION, KEY_USE_MAGICAL_GIRL_SYMBOLS } from '@/settings/user';
+import { KEY_AUTO_APPLY_POOL_MODIFICATIONS, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION, KEY_COLLAPSE_POOL_MODIFICATIONS, KEY_USE_MAGICAL_GIRL_SYMBOLS } from '@/settings/user';
 import SkillDataModel from '@/item/data/SkillDataModel';
 import GenesysItem from '@/item/GenesysItem';
 
@@ -25,11 +26,20 @@ import GenesysItem from '@/item/GenesysItem';
  */
 export const DEFAULT_SKILLS_COMPENDIUM = 'genesys.crb-skills';
 
+/**
+ * The default difficulty modifications to use if the setting is misconfigured.
+ */
+export const DEFAULT_DIFFICULTY = 'DD';
+
 export const GENESYS_CONFIG = {
-	/** World Settings **/
 	settings: {
+		/** World Settings **/
+
 		// Default skills compendium to use if the setting is misconfigured.
 		skillsCompendium: DEFAULT_SKILLS_COMPENDIUM,
+
+		// Default dice pool modifications that should be added to the dice pool when doing a check.
+		defaultDifficulty: DEFAULT_DIFFICULTY,
 
 		// The name of the skill to use for healing Critical Injuries.
 		skillForHealingInjury: 'Resilience',
@@ -56,6 +66,12 @@ export const GENESYS_CONFIG = {
 
 		// Whether to use the Magical Girl symbols where possible in the system.
 		useMagicalGirlSymbols: false,
+
+		// Wheter to collapse the 'Pool Modifications' section when a dice prompt renders.
+		startWithCollapsedPoolModifications: false,
+
+		// Wheter to automatically apply all the pool modifications shown on the dice prompt.
+		autoApplyPoolModifications: false,
 
 		// Wheter to show the chance to succeed of a dice pool by constructing permutations.
 		showChanceToSucceedFromPermutations: false,
@@ -85,8 +101,8 @@ export function register() {
  */
 export function ready() {
 	/** World Settings **/
-
 	game.settings.settings.get<string>(`${SETTINGS_NAMESPACE}.${KEY_SKILLS_COMPENDIUM}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_SKILLS_COMPENDIUM));
+	game.settings.settings.get<string>(`${SETTINGS_NAMESPACE}.${KEY_DEFAULT_DIFFICULTY}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_DEFAULT_DIFFICULTY));
 	game.settings.settings.get<string>(`${SETTINGS_NAMESPACE}.${KEY_SKILL_FOR_INJURIES}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_SKILL_FOR_INJURIES));
 	game.settings.settings.get<string>(`${SETTINGS_NAMESPACE}.${KEY_SKILL_FOR_REPAIRING_VEHICLE_HITS}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_SKILL_FOR_REPAIRING_VEHICLE_HITS));
 	game.settings.settings.get<string>(`${SETTINGS_NAMESPACE}.${KEY_MONEY_NAME}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_MONEY_NAME));
@@ -96,13 +112,9 @@ export function ready() {
 	game.settings.settings.get<boolean>(`${SETTINGS_NAMESPACE}.${KEY_SUPER_CHARACTERISTICS}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_SUPER_CHARACTERISTICS));
 
 	/** User Settings **/
-
 	CONFIG.genesys.settings.useMagicalGirlSymbols = game.settings.get<boolean>(SETTINGS_NAMESPACE, KEY_USE_MAGICAL_GIRL_SYMBOLS) ?? false;
-
-	// eslint-disable-next-line
-	if (!!game.workers.get) {
-		CONFIG.genesys.settings.showChanceToSucceedFromPermutations = game.settings.get<boolean>(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION) ?? false;
-	}
-
+	game.settings.settings.get<boolean>(`${SETTINGS_NAMESPACE}.${KEY_COLLAPSE_POOL_MODIFICATIONS}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_COLLAPSE_POOL_MODIFICATIONS));
+	game.settings.settings.get<boolean>(`${SETTINGS_NAMESPACE}.${KEY_AUTO_APPLY_POOL_MODIFICATIONS}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_AUTO_APPLY_POOL_MODIFICATIONS));
+	CONFIG.genesys.settings.showChanceToSucceedFromPermutations = game.settings.get<boolean>(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION) ?? false;
 	game.settings.settings.get<number>(`${SETTINGS_NAMESPACE}.${KEY_CHANCE_TO_SUCCEED_BY_SIMULATION}`)?.onChange?.(game.settings.get(SETTINGS_NAMESPACE, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION));
 }

--- a/src/dice/index.ts
+++ b/src/dice/index.ts
@@ -18,7 +18,7 @@ import './diceSoNice';
 /**
  * An object used to get general details of each dice type.
  */
-export const DieType = {
+export const GenesysDice = {
 	Proficiency: ProficiencyDie,
 	Ability: AbilityDie,
 	Boost: BoostDie,
@@ -32,7 +32,7 @@ export const DieType = {
  * Registers custom dice types.
  */
 export function register() {
-	Object.values(DieType).forEach((dieType) => {
+	Object.values(GenesysDice).forEach((dieType) => {
 		CONFIG.Dice.terms[dieType.DENOMINATION] = dieType;
 	});
 }

--- a/src/dice/types/GenesysPoolGradeOperation.ts
+++ b/src/dice/types/GenesysPoolGradeOperation.ts
@@ -1,0 +1,14 @@
+export const GenesysPoolGradeOperation = {
+	UpgradeAbility: {
+		GLYPH: '^',
+	},
+	DowngradeAbility: {
+		GLYPH: '_',
+	},
+	UpgradeDifficulty: {
+		GLYPH: '*',
+	},
+	DowngradeDifficulty: {
+		GLYPH: '~',
+	},
+};

--- a/src/effects/GenesysEffect.ts
+++ b/src/effects/GenesysEffect.ts
@@ -14,6 +14,13 @@ export default class GenesysEffect extends ActiveEffect {
 		return this.disabled;
 	}
 
+	// Prefix string used to identify active effects that are supposed to modify a dice pool that is using a specific
+	// skill.
+	static DICE_POOL_MOD_SKILL_PREFIX = 'genesys.pool.skill';
+
+	// The value of an effect that modifies the dice pool must be composed of 'tokens' that followe this pattern.
+	static DICE_POOL_MOD_SKILL_PATTERN = /(-?[BAPSDCasthfd]|[\^*_~])/g;
+
 	get originItem(): GenesysItem | undefined {
 		if (!this.origin || !(this.parent instanceof GenesysActor) || !this.origin.includes('.Item.')) {
 			return undefined;

--- a/src/effects/GenesysEffectSheet.scss
+++ b/src/effects/GenesysEffectSheet.scss
@@ -137,5 +137,9 @@
 		.header {
 			grid-template-columns: /* Key */ 2fr /* Change Mode */ 1fr /* Value */ 1fr /* Actions */ auto;
 		}
+
+		.hide-it {
+			display: none;
+		}
 	}
 }

--- a/src/effects/GenesysEffectSheet.ts
+++ b/src/effects/GenesysEffectSheet.ts
@@ -6,9 +6,20 @@
  * @file ActiveEffect configuration sheet
  */
 
+import GenesysEffect from '@/effects/GenesysEffect';
 import './GenesysEffectSheet.scss';
 
-export default class GenesysEffectSheet extends ActiveEffectConfig {
+type EffectChangeExpanded = foundry.data.EffectChangeSource & {
+	skill?: string;
+};
+
+type IncompleteSheetSubmitData = { changes: EffectChangeExpanded[] };
+
+// Pattern to identify an active effect that modifies the dice pool. It's also used to extract the skill that is tied
+// to the modification.
+const dicePoolModForSkillPattern = new RegExp(`(?<=${escapeRegExp(GenesysEffect.DICE_POOL_MOD_SKILL_PREFIX)})\\.`, 'g');
+
+export default class GenesysEffectSheet extends ActiveEffectConfig<GenesysEffect> {
 	static override get defaultOptions() {
 		return {
 			...super.defaultOptions,
@@ -29,8 +40,46 @@ export default class GenesysEffectSheet extends ActiveEffectConfig {
 		return 'systems/genesys/templates/sheets/effect-config.hbs';
 	}
 
+	override async getData(options?: DocumentSheetOptions) {
+		const data = await super.getData(options);
+
+		// The 'Custom' mode is not explicitly used.
+		delete data.modes[CONST.ACTIVE_EFFECT_MODES.CUSTOM];
+
+		// Make a copy of all the changes and do additional processing for the ones that deal with dice pool
+		// modifications. The reason to use copies is because we don't want to modify the effect itself by simply
+		// oppening the sheet.
+		const changes = [];
+		for (const change of data.data.changes) {
+			const thisChange = { ...change } as EffectChangeExpanded;
+			const extractDicePoolModForSkill = thisChange.key.split(dicePoolModForSkillPattern);
+			if (extractDicePoolModForSkill.length === 2) {
+				thisChange.key = GenesysEffect.DICE_POOL_MOD_SKILL_PREFIX;
+				thisChange.skill = extractDicePoolModForSkill[1];
+			}
+			changes.push(thisChange);
+		}
+
+		return foundry.utils.mergeObject(data, {
+			changes,
+			skills: Object.fromEntries(CONFIG.genesys.skills.map((skill) => [skill.name, skill.name])),
+		});
+	}
+
 	override activateListeners(html: JQuery) {
 		super.activateListeners(html);
+
+		// Make sure we show/hide the proper `select` elements when picking a dice pool modification.
+		html.find('.effect-change > select:first-child').on('change', (event) => {
+			const targetSelect = event.currentTarget as HTMLSelectElement;
+			if (targetSelect.value === GenesysEffect.DICE_POOL_MOD_SKILL_PREFIX) {
+				targetSelect.nextElementSibling?.classList.remove('hide-it');
+				targetSelect.nextElementSibling?.nextElementSibling?.classList.add('hide-it');
+			} else {
+				targetSelect.nextElementSibling?.classList.add('hide-it');
+				targetSelect.nextElementSibling?.nextElementSibling?.classList.remove('hide-it');
+			}
+		});
 
 		if (this.isEditable) {
 			// Foundry v10 and v11 bind this functionality differently so instead we override that behavior with our own.
@@ -53,4 +102,28 @@ export default class GenesysEffectSheet extends ActiveEffectConfig {
 
 		return await fp.browse();
 	}
+
+	protected override _getSubmitData(updateData?: Record<string, unknown>) {
+		const dicePoolModificationPattern = new RegExp(`^${GenesysEffect.DICE_POOL_MOD_SKILL_PATTERN.source}*$`);
+		const submitData = super._getSubmitData(updateData) as IncompleteSheetSubmitData;
+
+		// Loop through all the changes and make sure to construct the proper key for those that deal with dice pool
+		// modifications.
+		for (const change of submitData.changes) {
+			if (change.key === GenesysEffect.DICE_POOL_MOD_SKILL_PREFIX) {
+				change.key += `.${change.skill}`;
+				change.mode = CONST.ACTIVE_EFFECT_MODES.CUSTOM;
+				if (!dicePoolModificationPattern.test(change.value)) {
+					change.value = '';
+				}
+				delete change.skill;
+			}
+		}
+		return submitData;
+	}
+}
+
+// Helper function to escape special characters used by regular expressions in strings that we want to match exactly.
+function escapeRegExp(raw: string) {
+	return raw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/item/data/InjuryDataModel.ts
+++ b/src/item/data/InjuryDataModel.ts
@@ -11,7 +11,7 @@ export default abstract class InjuryDataModel extends BaseItemDataModel {
 	/**
 	 * Severity level of the injury, which aligns with Difficulty levels to heal it.
 	 */
-	abstract severity: '-' | 'easy' | 'average' | 'hard' | 'daunting';
+	abstract severity: '-' | 'easy' | 'average' | 'hard' | 'daunting' | 'formidable';
 
 	static override defineSchema() {
 		const fields = foundry.data.fields;
@@ -20,7 +20,7 @@ export default abstract class InjuryDataModel extends BaseItemDataModel {
 			...super.defineSchema(),
 			severity: new fields.StringField({
 				initial: 'average',
-				choices: ['-', 'easy', 'average', 'hard', 'daunting'],
+				choices: ['-', 'easy', 'average', 'hard', 'daunting', 'formidable'],
 			}),
 		};
 	}

--- a/src/settings/campaign.ts
+++ b/src/settings/campaign.ts
@@ -6,7 +6,8 @@
  * @file System settings data related to campaign setting customization.
  */
 
-import { GENESYS_CONFIG } from '@/config';
+import { DEFAULT_DIFFICULTY, DEFAULT_SKILLS_COMPENDIUM, GENESYS_CONFIG } from '@/config';
+import GenesysEffect from '@/effects/GenesysEffect';
 import SkillDataModel from '@/item/data/SkillDataModel';
 import GenesysItem from '@/item/GenesysItem';
 
@@ -14,6 +15,11 @@ import GenesysItem from '@/item/GenesysItem';
  * The Skills Compendium to use for default skill data.
  */
 export const KEY_SKILLS_COMPENDIUM = 'skillsCompendium';
+
+/**
+ * The default difficulty of a check.
+ */
+export const KEY_DEFAULT_DIFFICULTY = 'defaultDifficulty';
 
 /**
  * The name of the skill to use for healing Critical Injuries.
@@ -64,7 +70,7 @@ export function register(namespace: string) {
 		type: String,
 		onChange: async (value) => {
 			// We always want a skill compendium so fallback to the default value if it's ever removed.
-			let skillsCompendiumName = GENESYS_CONFIG.settings.skillsCompendium;
+			let skillsCompendiumName = DEFAULT_SKILLS_COMPENDIUM;
 			if (!value) {
 				ui.notifications.warn('Genesys.Notifications.NoSkillsCompendium', { localize: true });
 				CONFIG.genesys.settings.skillsCompendium = skillsCompendiumName;
@@ -87,6 +93,20 @@ export function register(namespace: string) {
 			}
 
 			CONFIG.genesys.skills = skills;
+		},
+	});
+
+	game.settings.register(namespace, KEY_DEFAULT_DIFFICULTY, {
+		name: game.i18n.localize('Genesys.Settings.DefaultDifficulty'),
+		hint: game.i18n.localize('Genesys.Settings.DefaultDifficultyHint'),
+		scope: 'world',
+		config: true,
+		default: GENESYS_CONFIG.settings.defaultDifficulty,
+		type: String,
+		onChange: (value) => {
+			const difficulty = value ?? '';
+			const difficultyPattern = new RegExp(`^${GenesysEffect.DICE_POOL_MOD_SKILL_PATTERN.source}*$`);
+			CONFIG.genesys.settings.defaultDifficulty = difficultyPattern.test(difficulty) ? difficulty : DEFAULT_DIFFICULTY;
 		},
 	});
 

--- a/src/settings/user.ts
+++ b/src/settings/user.ts
@@ -14,6 +14,16 @@ import { GENESYS_CONFIG } from '@/config';
 export const KEY_USE_MAGICAL_GIRL_SYMBOLS = 'useMagicalGirlSymbols';
 
 /**
+ * Wheter to collapse the 'Pool Modifications' section when a dice prompt renders.
+ */
+export const KEY_COLLAPSE_POOL_MODIFICATIONS = 'dicePoolCollapseModificationsDetails';
+
+/**
+ * Wheter to automatically apply all the pool modifications shown on the dice prompt.
+ */
+export const KEY_AUTO_APPLY_POOL_MODIFICATIONS = 'dicePoolAutoApplyModifications';
+
+/**
  * Wheter the user wants to calculate the chance to succeed by constructing the permutations on a Web Worker.
  */
 export const KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION = 'dicePoolChanceToSucceedByPermutation';
@@ -34,20 +44,41 @@ export function register(namespace: string) {
 		requiresReload: true,
 	});
 
-	// This setting is only available for FVTT v11+ because it depends on the changes made to the workers API
-	// introduced in that version.
-	// eslint-disable-next-line
-	if (!!game.workers.get) {
-		game.settings.register(namespace, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION, {
-			name: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedByPermutation'),
-			hint: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedByPermutationHint'),
-			scope: 'client',
-			config: true,
-			default: GENESYS_CONFIG.settings.showChanceToSucceedFromPermutations,
-			type: Boolean,
-			requiresReload: true,
-		});
-	}
+	game.settings.register(namespace, KEY_COLLAPSE_POOL_MODIFICATIONS, {
+		name: game.i18n.localize('Genesys.Settings.DicePoolCollapseModifications'),
+		hint: game.i18n.localize('Genesys.Settings.DicePoolCollapseModificationsHint'),
+		scope: 'client',
+		config: true,
+		default: GENESYS_CONFIG.settings.startWithCollapsedPoolModifications,
+		type: Boolean,
+		onChange: (value) => {
+			const valueAsBool = (value as unknown as boolean) ?? false;
+			CONFIG.genesys.settings.startWithCollapsedPoolModifications = valueAsBool;
+		},
+	});
+
+	game.settings.register(namespace, KEY_AUTO_APPLY_POOL_MODIFICATIONS, {
+		name: game.i18n.localize('Genesys.Settings.DicePoolAutoApplyModifications'),
+		hint: game.i18n.localize('Genesys.Settings.DicePoolAutoApplyModificationsHint'),
+		scope: 'client',
+		config: true,
+		default: GENESYS_CONFIG.settings.autoApplyPoolModifications,
+		type: Boolean,
+		onChange: (value) => {
+			const valueAsBool = (value as unknown as boolean) ?? false;
+			CONFIG.genesys.settings.autoApplyPoolModifications = valueAsBool;
+		},
+	});
+
+	game.settings.register(namespace, KEY_CHANCE_TO_SUCCEED_BY_PERMUTATION, {
+		name: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedByPermutation'),
+		hint: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedByPermutationHint'),
+		scope: 'client',
+		config: !!game.workers.get, // eslint-disable-line -- Only show setting for FVTT v11+
+		default: GENESYS_CONFIG.settings.showChanceToSucceedFromPermutations,
+		type: Boolean,
+		requiresReload: true,
+	});
 
 	game.settings.register(namespace, KEY_CHANCE_TO_SUCCEED_BY_SIMULATION, {
 		name: game.i18n.localize('Genesys.Settings.DicePoolChanceToSucceedBySimulation'),

--- a/src/vue/apps/DicePrompt.vue
+++ b/src/vue/apps/DicePrompt.vue
@@ -8,19 +8,23 @@ import SkillDataModel from '@/item/data/SkillDataModel';
 import { RootContext } from '@/vue/SheetContext';
 import Localized from '@/vue/components/Localized.vue';
 import MinionDataModel from '@/actor/data/MinionDataModel';
-import { DieType } from '@/dice';
+import { GenesysDice } from '@/dice';
 import { DieCategory } from '@/dice/types/GenesysDie';
 import { GenesysSymbol } from '@/dice/types/GenesysSymbol';
 import CharacterDataModel from '@/actor/data/CharacterDataModel';
 import AdversaryDataModel from '@/actor/data/AdversaryDataModel';
 import GenesysActor from '@/actor/GenesysActor';
+import { GenesysPoolGradeOperation } from '@/dice/types/GenesysPoolGradeOperation';
+import GenesysEffect from '@/effects/GenesysEffect';
 
 type AlsoNone<T> = T | undefined;
 type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>;
 
-type DieName = keyof typeof DieType;
+type DieName = keyof typeof GenesysDice;
 type SymbolName = keyof typeof GenesysSymbol;
-type PoolEntity = DieName | SymbolName;
+type DieGradeOperationName = keyof typeof GenesysPoolGradeOperation;
+type SimplePoolEntity = DieName | SymbolName;
+type PoolEntity = SimplePoolEntity | DieGradeOperationName;
 
 type NonVehicleActorDataModel = CharacterDataModel | AdversaryDataModel;
 
@@ -30,7 +34,90 @@ type DicePool = {
 	usesSuperCharacteristic: boolean;
 };
 
-const SORT_ORDER: Record<PoolEntity, number> = {
+type DicePoolModifications = {
+	baseDifficulty: string[];
+	manualChanges: string[];
+	effects: Array<{
+		name: string;
+		enabled: boolean;
+		mods: string[];
+	}>;
+};
+
+type PoolModificationData = {
+	targetName: PoolEntity;
+	icon: { baseName: string; baseGlyph: string; operator: string };
+	sort: number;
+};
+
+const POOL_MODIFICATIONS_DATA: Record<string, PoolModificationData> = Object.fromEntries([
+	...Object.entries(GenesysDice).map(([dieName, dieType]) => [
+		dieType.GLYPH,
+		{
+			targetName: dieName,
+			icon: { baseName: dieName, baseGlyph: dieType.GLYPH, operator: 'fa-plus' },
+			sort: 0,
+		},
+	]),
+	[
+		GenesysPoolGradeOperation.UpgradeAbility.GLYPH,
+		{
+			targetName: 'UpgradeAbility',
+			icon: { baseName: 'Ability', baseGlyph: GenesysDice['Ability'].GLYPH, operator: 'fa-arrow-up' },
+			sort: 1,
+		},
+	],
+	[
+		GenesysPoolGradeOperation.UpgradeDifficulty.GLYPH,
+		{
+			targetName: 'UpgradeDifficulty',
+			icon: { baseName: 'Difficulty', baseGlyph: GenesysDice['Difficulty'].GLYPH, operator: 'fa-arrow-up' },
+			sort: 1,
+		},
+	],
+	[
+		GenesysPoolGradeOperation.DowngradeAbility.GLYPH,
+		{
+			targetName: 'DowngradeAbility',
+			icon: { baseName: 'Proficiency', baseGlyph: GenesysDice['Proficiency'].GLYPH, operator: 'fa-arrow-down' },
+			sort: 2,
+		},
+	],
+	[
+		GenesysPoolGradeOperation.DowngradeDifficulty.GLYPH,
+		{
+			targetName: 'DowngradeDifficulty',
+			icon: { baseName: 'Challenge', baseGlyph: GenesysDice['Challenge'].GLYPH, operator: 'fa-arrow-down' },
+			sort: 2,
+		},
+	],
+	...Object.entries(GenesysDice).map(([dieName, dieType]) => [
+		`-${dieType.GLYPH}`,
+		{
+			targetName: dieName,
+			icon: { baseName: dieName, baseGlyph: dieType.GLYPH, operator: 'fa-minus' },
+			sort: 3,
+		},
+	]),
+	...Object.entries(GenesysSymbol).map(([symbolName, symbolType]) => [
+		symbolType.GLYPH,
+		{
+			targetName: symbolName,
+			icon: { baseName: symbolName, baseGlyph: symbolType.GLYPH, operator: 'fa-plus' },
+			sort: 4,
+		},
+	]),
+	...Object.entries(GenesysSymbol).map(([symbolName, symbolType]) => [
+		`-${symbolType.GLYPH}`,
+		{
+			targetName: symbolName,
+			icon: { baseName: symbolName, baseGlyph: symbolType.GLYPH, operator: 'fa-minus' },
+			sort: 5,
+		},
+	]),
+]);
+
+const SORT_ORDER: Record<SimplePoolEntity, number> = {
 	Proficiency: 0,
 	Ability: 1,
 	Boost: 2,
@@ -51,23 +138,30 @@ const SORT_ORDER: Record<PoolEntity, number> = {
 const USE_UNCOUPLED_SKILLS = CONFIG.genesys.settings.uncoupleSkillsFromCharacteristics;
 const USE_SUPER_CHARACTERISTICS = CONFIG.genesys.settings.useSuperCharacteristics;
 const CHANCE_TO_SUCCEED_BY_SIMULATION_NUM_ROLLS = CONFIG.genesys.settings.showChanceToSucceedFromSimulations.amountOfRolls;
-const USE_CHANCE_TO_SUCCEED_BY_PERMUTATION = !!game.workers.get && CONFIG.genesys.settings.showChanceToSucceedFromPermutations; // eslint-disable-line
+const USE_CHANCE_TO_SUCCEED_BY_PERMUTATION = CONFIG.genesys.settings.showChanceToSucceedFromPermutations;
 const USE_CHANCE_TO_SUCCEED = USE_CHANCE_TO_SUCCEED_BY_PERMUTATION || CONFIG.genesys.settings.showChanceToSucceedFromSimulations.enabled;
 
 const context = inject<DicePromptContext>(RootContext)!;
 
-const positiveDice = ref<DieName[]>([]);
-const negativeDice = ref<DieName[]>([]);
-const positiveSymbols = ref<SymbolName[]>([]);
-const negativeSymbols = ref<SymbolName[]>([]);
+const currentDicePool = ref<DicePool>({
+	dice: {},
+	symbols: {},
+	usesSuperCharacteristic: false,
+});
+const poolModifications = ref<DicePoolModifications>({
+	baseDifficulty: [],
+	manualChanges: [],
+	effects: [],
+});
 const availableSkills = ref<GenesysItem<SkillDataModel>[]>([]);
 const selectedSkill = ref<AlsoNone<GenesysItem<SkillDataModel>>>();
 const selectedCharacteristic = ref<AlsoNone<Characteristic>>();
 const probabilityOfSuccess = ref<AlsoNone<string>>();
 
 const useSuperCharacteristic = ref(false);
+const showPoolModifications = ref(!CONFIG.genesys.settings.startWithCollapsedPoolModifications);
 
-let currentDicePool: DicePool = {
+let previousDicePool: DicePool = {
 	dice: {},
 	symbols: {},
 	usesSuperCharacteristic: false,
@@ -75,255 +169,183 @@ let currentDicePool: DicePool = {
 
 onMounted(() => {
 	const actor = toRaw(context.actor);
-	negativeDice.value = new Array<DieName>(context.difficulty).fill('Difficulty');
-	availableSkills.value = actor ? (actor.items.filter((item) => item.type === 'skill') as GenesysItem<SkillDataModel>[]).sort(sortSkills) : [];
+
+	poolModifications.value.baseDifficulty = context.difficulty.match(GenesysEffect.DICE_POOL_MOD_SKILL_PATTERN)?.sort(sortPoolModifications) ?? [];
+	availableSkills.value = actor
+		? (actor.items.filter((item) => item.type === 'skill') as GenesysItem<SkillDataModel>[]).sort((f, s) => {
+				const nameA = f.name.toLowerCase();
+				const nameB = s.name.toLowerCase();
+				return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
+			})
+		: [];
 	selectedSkill.value = context.skillName ? (availableSkills.value.find((skill) => skill.name === context.skillName) as AlsoNone<GenesysItem<SkillDataModel>>) : undefined;
 	selectedCharacteristic.value = selectedSkill.value?.systemData.characteristic ?? context.rollUnskilled;
 
-	if (actor) {
-		recalculateDicePool();
-	}
-
-	approximateProbability();
+	calculatePoolModificationsForSkill();
+	buildDicePool();
 });
 
-function onSkillChange(event: Event) {
-	const selectedOption = event.currentTarget as HTMLSelectElement;
-
-	selectedSkill.value = availableSkills.value.find((s) => s.id === selectedOption.value) as AlsoNone<GenesysItem<SkillDataModel>>;
-	selectedCharacteristic.value = selectedSkill.value?.systemData.characteristic;
-
-	recalculateDicePool();
+// Helper function for sorting dice pool modifications. These are sorted according to the steps used for modifying a
+// dice pool:
+//  1- Adding dice
+//  2- Upgrading dice
+//  3- Downgrading dice
+//  4- Removing dice
+//  5- Adding symbols (this is not a formal step but adding it here is done for convenience since it doesn't interfere)
+//  6- Removing symbols (see above)
+function sortPoolModifications(left: string, right: string) {
+	return POOL_MODIFICATIONS_DATA[left].sort - POOL_MODIFICATIONS_DATA[right].sort;
 }
 
-function onCharacteristicChange(event: Event) {
-	const selectedOption = event.currentTarget as HTMLSelectElement;
+function applyDicePoolModifications(dicePool: DicePool, modifierTokens: string[]) {
+	for (const modifierToken of modifierTokens) {
+		if (modifierToken === '^' || modifierToken === '*') {
+			const [baseDice, upgradeDice]: DieName[] = modifierToken === '^' ? ['Ability', 'Proficiency'] : ['Difficulty', 'Challenge'];
+			if (dicePool.dice[baseDice]) {
+				dicePool.dice[baseDice]!--;
+				dicePool.dice[upgradeDice] = 1 + (dicePool.dice[upgradeDice] ?? 0);
+			} else {
+				dicePool.dice[baseDice] = 1 + (dicePool.dice[baseDice] ?? 0);
+			}
+		} else if (modifierToken === '_' || modifierToken === '~') {
+			const [baseDice, downgradeDice]: DieName[] = modifierToken === '_' ? ['Proficiency', 'Ability'] : ['Challenge', 'Difficulty'];
+			if (dicePool.dice[baseDice]) {
+				dicePool.dice[baseDice]!--;
+				dicePool.dice[downgradeDice] = 1 + (dicePool.dice[downgradeDice] ?? 0);
+			}
+		} else {
+			// If we reach this branch then the glyph is for a dice or symbol.
+			let targetEntity = modifierToken;
+			let direction = 1;
 
-	selectedCharacteristic.value = selectedOption.value !== '-' ? (selectedOption.value as Characteristic) : undefined;
+			// If the glyph has two characters then the first one is signaling a removal.
+			if (modifierToken.length === 2) {
+				targetEntity = modifierToken[1];
+				direction = -1;
+			}
 
-	recalculateDicePool();
-}
+			// Check which sub pool we want to modify. Note that dice glyphs are always uppercase letters while symbols
+			// use lowercase letters.
+			const targetSubPool: PartialRecord<PoolEntity, number> = targetEntity === targetEntity.toUpperCase() ? dicePool.dice : dicePool.symbols;
+			const entityName = POOL_MODIFICATIONS_DATA[targetEntity].targetName;
 
-/**
- * Sorting function for sorting dice & symbol arrays.
- */
-function sortPoolEntities(f: PoolEntity, s: PoolEntity) {
-	return SORT_ORDER[f] - SORT_ORDER[s];
-}
-
-/**
- * Utility method to sort skills alphabetically.
- */
-function sortSkills(f: GenesysItem, s: GenesysItem) {
-	const nameA = f.name.toLowerCase();
-	const nameB = s.name.toLowerCase();
-
-	if (nameA < nameB) {
-		return -1;
-	}
-	if (nameA > nameB) {
-		return 1;
-	}
-
-	return 0;
-}
-
-/**
- * Reduce arrays of dice or symbols into an object mapping the entity to the number of times it appears in the array.
- */
-function reducePool(pool: PartialRecord<PoolEntity, number>, entity: PoolEntity) {
-	if (pool[entity] === undefined) {
-		pool[entity] = 1;
-	} else {
-		pool[entity]! += 1;
-	}
-
-	return pool;
-}
-
-/**
- * Clear the Positive Dice Pool and re-establish the base Ability & Challenge dice based on Characteristic & Skill Ranks.
- */
-function recalculateDicePool() {
-	// Do nothing if the characteristic & skill are both unselected.
-	if (!selectedCharacteristic.value && !selectedSkill.value) {
-		return;
-	}
-
-	const actor = context.actor as GenesysActor<NonVehicleActorDataModel>;
-
-	const characteristicValue = selectedCharacteristic.value ? actor.systemData.characteristics[selectedCharacteristic.value] : 0;
-	let skillValue = selectedSkill.value?.systemData.rank ?? 0;
-
-	if (actor.type === 'minion' && selectedSkill.value) {
-		skillValue = Math.max(0, (actor.systemData as MinionDataModel).remainingMembers - 1);
-	}
-
-	// Clear the Ability & Proficiency dice in the pool, but leave Boost Dice alone.
-	const boostDice = positiveDice.value.filter((dice) => dice === 'Boost');
-
-	const proficiencyDice = Math.min(characteristicValue, skillValue);
-	const abilityDice = Math.max(characteristicValue, skillValue) - proficiencyDice;
-
-	positiveDice.value = [...new Array<DieName>(proficiencyDice).fill('Proficiency'), ...new Array<DieName>(abilityDice).fill('Ability'), ...boostDice];
-
-	approximateProbability();
-}
-
-function addDie(dieName: DieName) {
-	const dice = DieType[dieName].CATEGORY === 'positive' ? positiveDice : negativeDice;
-
-	dice.value.push(dieName);
-	dice.value.sort(sortPoolEntities);
-
-	approximateProbability();
-}
-
-function removeDie(dieName: DieName, index: number) {
-	const dice = DieType[dieName].CATEGORY === 'positive' ? positiveDice : negativeDice;
-
-	dice.value.splice(index, 1);
-
-	approximateProbability();
-}
-
-function addSymbol(symbolName: SymbolName) {
-	const symbols = GenesysSymbol[symbolName].CATEGORY === 'positive' ? positiveSymbols : negativeSymbols;
-
-	symbols.value.push(symbolName);
-	symbols.value.sort(sortPoolEntities);
-
-	approximateProbability();
-}
-
-function removeSymbol(symbolName: SymbolName, index: number) {
-	const symbols = GenesysSymbol[symbolName].CATEGORY === 'positive' ? positiveSymbols : negativeSymbols;
-
-	symbols.value.splice(index, 1);
-
-	approximateProbability();
-}
-
-function upgradeDie(dieCategory: DieCategory) {
-	let dice = negativeDice;
-	let baseDie: DieName = 'Difficulty';
-	let upgradedDie: DieName = 'Challenge';
-
-	if (dieCategory === 'positive') {
-		// eslint-disable-next-line vue/no-ref-as-operand
-		dice = positiveDice;
-		baseDie = 'Ability';
-		upgradedDie = 'Proficiency';
-	}
-
-	const index = dice.value.findIndex((d) => d === baseDie);
-	if (index >= 0) {
-		dice.value[index] = upgradedDie;
-	} else {
-		dice.value.push(baseDie);
-		dice.value.sort(sortPoolEntities);
-	}
-
-	approximateProbability();
-}
-
-function downgradeDie(dieCategory: DieCategory) {
-	let dice = negativeDice;
-	let baseDie: DieName = 'Challenge';
-	let downgradedDie: DieName = 'Difficulty';
-
-	if (dieCategory === 'positive') {
-		//eslint-disable-next-line vue/no-ref-as-operand
-		dice = positiveDice;
-		baseDie = 'Proficiency';
-		downgradedDie = 'Ability';
-	}
-
-	const index = dice.value.findIndex((d) => d === baseDie);
-	if (index >= 0) {
-		dice.value[index] = downgradedDie;
-		dice.value.sort(sortPoolEntities);
-	}
-
-	approximateProbability();
-}
-
-function compileDicePool() {
-	const dice: PartialRecord<DieName, number> = positiveDice.value.concat(negativeDice.value).reduce(reducePool, {});
-	const symbols: PartialRecord<SymbolName, number> = positiveSymbols.value.concat(negativeSymbols.value).reduce(reducePool, {});
-
-	let poolHasSuperCharacteristic = useSuperCharacteristic.value;
-	if (USE_SUPER_CHARACTERISTICS) {
-		if (context.actor) {
-			const actor = context.actor as GenesysActor<NonVehicleActorDataModel>;
-			poolHasSuperCharacteristic = !!selectedCharacteristic.value && actor.systemData.superCharacteristics.has(selectedCharacteristic.value);
+			// Do not let the number of dice or symbols be a negative value.
+			if (direction > 0 || targetSubPool[entityName]) {
+				targetSubPool[entityName] = direction + (targetSubPool[entityName] ?? 0);
+			}
 		}
 	}
+}
 
-	const formula = Object.keys(dice)
-		.map((dieKey) => {
+function calculatePoolModificationsForSkill() {
+	const actor = toRaw(context.actor);
+	let relevantModifications: DicePoolModifications['effects'] = [];
+
+	if (actor && selectedSkill.value) {
+		const targetChangeKey = `${GenesysEffect.DICE_POOL_MOD_SKILL_PREFIX}.${selectedSkill.value.name}`;
+		relevantModifications = actor.effects.reduce(
+			(modifications, effect) => {
+				if (!effect.isSuppressed) {
+					// Find all the changes inside this effect that apply to the selected skill.
+					const relevantChanges = effect.changes.reduce((accum, change) => {
+						if (change.key === targetChangeKey) {
+							accum.push(...(change.value.match(GenesysEffect.DICE_POOL_MOD_SKILL_PATTERN)?.sort(sortPoolModifications) ?? []));
+						}
+						return accum;
+					}, [] as string[]);
+
+					if (relevantChanges.length > 0) {
+						modifications.push({
+							name: effect.name,
+							enabled: CONFIG.genesys.settings.autoApplyPoolModifications,
+							mods: relevantChanges.sort(sortPoolModifications),
+						});
+					}
+				}
+				return modifications;
+			},
+			[] as DicePoolModifications['effects'],
+		);
+	}
+
+	poolModifications.value.effects = relevantModifications;
+}
+
+function buildDicePool() {
+	const actor = context.actor as AlsoNone<GenesysActor<NonVehicleActorDataModel>>;
+	let proficiencyDice;
+	let abilityDice;
+	let usesSuperCharacteristic = USE_SUPER_CHARACTERISTICS;
+
+	// Step 1: Applying Skills and Characteristics
+	if (actor) {
+		const characteristicValue = selectedCharacteristic.value ? actor.systemData.characteristics[selectedCharacteristic.value] : 0;
+		let skillValue = selectedSkill.value?.systemData.rank ?? 0;
+
+		if (actor.type === 'minion' && selectedSkill.value) {
+			skillValue = Math.max(0, (actor.systemData as MinionDataModel).remainingMembers - 1);
+		}
+
+		proficiencyDice = Math.min(characteristicValue, skillValue);
+		abilityDice = Math.max(characteristicValue, skillValue) - proficiencyDice;
+		usesSuperCharacteristic &&= !!selectedCharacteristic.value && actor.systemData.superCharacteristics.has(selectedCharacteristic.value);
+	} else {
+		proficiencyDice = 0;
+		abilityDice = 0;
+		usesSuperCharacteristic &&= useSuperCharacteristic.value;
+	}
+
+	const dicePool = {
+		dice: {
+			Proficiency: proficiencyDice,
+			Ability: abilityDice,
+		},
+		symbols: {},
+		usesSuperCharacteristic,
+	};
+	const modifications = poolModifications.value;
+
+	// Step 2: Applying Task Difficulty
+	applyDicePoolModifications(dicePool, modifications.baseDifficulty);
+
+	// Step 3: Modifying a Dice Pool
+	const activeModifications = [...modifications.manualChanges];
+	modifications.effects.forEach((effect) => {
+		if (effect.enabled) {
+			activeModifications.push(...effect.mods);
+		}
+	});
+
+	// We sort the modifications so that they follow the proper sub-steps when applied to the dice pool.
+	applyDicePoolModifications(dicePool, activeModifications.sort(sortPoolModifications));
+	currentDicePool.value = dicePool;
+
+	approximateProbability();
+}
+
+function compileDiceFormula() {
+	const usesSuperCharacteristic = currentDicePool.value.usesSuperCharacteristic;
+	const formula = Object.entries(currentDicePool.value.dice)
+		.map(([dieKey, dieAmount]) => {
 			const dieName = dieKey as DieName;
-			const explodeDice = dieName === 'Proficiency' && poolHasSuperCharacteristic ? 'X' : '';
-			return `${dice[dieName]}${DieType[dieName].FORMULA}${explodeDice}`;
+			const explodeDice = dieName === 'Proficiency' && usesSuperCharacteristic ? 'X' : '';
+			return `${dieAmount}${GenesysDice[dieName].FORMULA}${explodeDice}`;
 		})
 		.join('+');
 
-	return {
-		formula: formula === '' ? '0' : formula,
-		usesSuperCharacteristic: poolHasSuperCharacteristic && !!dice['Proficiency'],
-		dice,
-		symbols,
-	};
+	return formula === '' ? '0' : formula;
 }
 
 // Convert the symbols object into the old format to make the GenesysRoller understand it.
 // A refactor of said class should get rid of this method.
-function convertToOldSymbolsFormat(symbols: PartialRecord<SymbolName, number>) {
-	return Object.entries(symbols).reduce(
+function compileSymbolsData() {
+	return Object.entries(currentDicePool.value.symbols).reduce(
 		(accum, [symbolName, symbolAmount]) => {
 			accum[GenesysSymbol[symbolName as SymbolName].GLYPH] = symbolAmount;
 			return accum;
 		},
 		{} as Record<string, number>,
 	);
-}
-
-async function rollPool() {
-	const { formula, symbols } = compileDicePool();
-
-	const oldFormatSymbols = convertToOldSymbolsFormat(symbols);
-	const baseRollData = {
-		actor: toRaw(context.actor),
-		characteristic: selectedCharacteristic.value,
-		skillId: selectedSkill.value?.id ?? '-',
-		formula,
-		symbols: oldFormatSymbols,
-	};
-
-	switch (context.rollType) {
-		case RollType.Simple:
-			await GenesysRoller.skillRoll(baseRollData);
-			break;
-
-		case RollType.Attack:
-			await GenesysRoller.attackRoll({
-				...baseRollData,
-				weapon: (context.rollData as AttackRollData).weapon,
-			});
-			break;
-
-		case RollType.Initiative:
-			(context.rollData as InitiativeRollData).resolvePromise({
-				roll: new Roll(formula, { symbols: oldFormatSymbols }),
-				skillName: selectedSkill.value?.name ?? 'Unskilled',
-			});
-			break;
-
-		default:
-			await GenesysRoller.skillRoll(baseRollData);
-	}
-
-	await context.app.close();
 }
 
 function hasSameChanceToSucceed(firstDicePool: DicePool, secondDicePool: DicePool) {
@@ -356,26 +378,21 @@ async function approximateProbability() {
 		return;
 	}
 
-	const { formula, usesSuperCharacteristic, dice, symbols } = compileDicePool();
-
-	const previousDicePool = currentDicePool;
-	currentDicePool = {
-		dice: dice,
-		symbols: symbols,
-		usesSuperCharacteristic,
-	};
+	const dicePool = currentDicePool.value;
+	const obsoleteDicePool = previousDicePool;
+	previousDicePool = dicePool;
 
 	// Slight optimization for a pool without dice.
-	if (!Object.keys(dice).length) {
-		const totalSuccesses = (symbols.Success ?? 0) + (symbols.Triumph ?? 0);
-		const totalFailures = (symbols.Failure ?? 0) + (symbols.Despair ?? 0);
+	if (Object.keys(dicePool.dice).length === 0) {
+		const totalSuccesses = (dicePool.symbols.Success ?? 0) + (dicePool.symbols.Triumph ?? 0);
+		const totalFailures = (dicePool.symbols.Failure ?? 0) + (dicePool.symbols.Despair ?? 0);
 		const deterministicResult = totalSuccesses > totalFailures ? 100 : 0;
 		probabilityOfSuccess.value = deterministicResult.toFixed(2);
 		return;
 	}
 
 	// No need to run this process again if nothing of importance has changed.
-	if (hasSameChanceToSucceed(previousDicePool, currentDicePool)) {
+	if (hasSameChanceToSucceed(obsoleteDicePool, dicePool)) {
 		return;
 	}
 
@@ -387,15 +404,18 @@ async function approximateProbability() {
 			return;
 		}
 
+		const rawDicePool = toRaw(dicePool);
 		chanceToSucceed = (await worker.executeFunction('calculateChanceForDicePool', {
-			dicePool: dice,
-			extraSymbols: symbols,
+			dicePool: rawDicePool.dice,
+			extraSymbols: rawDicePool.symbols,
 			criteriaType: 'SUCCESS',
 		})) as number;
 	} else {
+		const formula = compileDiceFormula();
+		const symbols = compileSymbolsData();
 		const simulation = await Promise.all(
 			[...Array(CHANCE_TO_SUCCEED_BY_SIMULATION_NUM_ROLLS)].map(async () => {
-				const roll = new Roll(formula, { symbols: convertToOldSymbolsFormat(symbols) });
+				const roll = new Roll(formula, { symbols });
 				const result = await roll.evaluate({ async: true });
 				return GenesysRoller.parseRollResults(result);
 			}),
@@ -405,6 +425,94 @@ async function approximateProbability() {
 	}
 
 	probabilityOfSuccess.value = (Math.round(chanceToSucceed * 10000) / 100).toFixed(2);
+}
+
+function onSkillChange(event: Event) {
+	const selectedOption = event.currentTarget as HTMLSelectElement;
+	selectedSkill.value = availableSkills.value.find((s) => s.id === selectedOption.value) as AlsoNone<GenesysItem<SkillDataModel>>;
+	selectedCharacteristic.value = selectedSkill.value?.systemData.characteristic;
+
+	calculatePoolModificationsForSkill();
+	buildDicePool();
+}
+
+function onCharacteristicChange(event: Event) {
+	const selectedOption = event.currentTarget as HTMLSelectElement;
+	selectedCharacteristic.value = selectedOption.value !== '-' ? (selectedOption.value as Characteristic) : undefined;
+
+	buildDicePool();
+}
+
+function getOrderedDice(category: DieCategory) {
+	return Object.entries(currentDicePool.value.dice)
+		.filter(([dieName]) => GenesysDice[dieName as DieName].CATEGORY === category)
+		.sort(([left], [right]) => SORT_ORDER[left as DieName] - SORT_ORDER[right as DieName]);
+}
+
+function getOrderedSymbols(category: DieCategory) {
+	return Object.entries(currentDicePool.value.symbols)
+		.filter(([symbolName]) => GenesysSymbol[symbolName as SymbolName].CATEGORY === category)
+		.sort(([left], [right]) => SORT_ORDER[left as SymbolName] - SORT_ORDER[right as SymbolName]);
+}
+
+function addDiceOperation(dieName: DieName, isRemoval: boolean = false) {
+	poolModifications.value.manualChanges.push(`${isRemoval ? '-' : ''}${GenesysDice[dieName].GLYPH}`);
+	poolModifications.value.manualChanges.sort(sortPoolModifications);
+	buildDicePool();
+}
+
+function addSymbolOperation(symbolName: SymbolName, isRemoval: boolean = false) {
+	poolModifications.value.manualChanges.push(`${isRemoval ? '-' : ''}${GenesysSymbol[symbolName].GLYPH}`);
+	poolModifications.value.manualChanges.sort(sortPoolModifications);
+	buildDicePool();
+}
+
+function addPoolOperation(operationName: DieGradeOperationName) {
+	poolModifications.value.manualChanges.push(GenesysPoolGradeOperation[operationName].GLYPH);
+	poolModifications.value.manualChanges.sort(sortPoolModifications);
+	buildDicePool();
+}
+
+function removeManualChange(index: number) {
+	poolModifications.value.manualChanges.splice(index, 1);
+	buildDicePool();
+}
+
+async function rollPool() {
+	const formula = compileDiceFormula();
+	const symbols = compileSymbolsData();
+	const baseRollData = {
+		actor: toRaw(context.actor),
+		characteristic: selectedCharacteristic.value,
+		skillId: selectedSkill.value?.id ?? '-',
+		formula,
+		symbols,
+	};
+
+	switch (context.rollType) {
+		case RollType.Simple:
+			await GenesysRoller.skillRoll(baseRollData);
+			break;
+
+		case RollType.Attack:
+			await GenesysRoller.attackRoll({
+				...baseRollData,
+				weapon: (context.rollData as AttackRollData).weapon,
+			});
+			break;
+
+		case RollType.Initiative:
+			(context.rollData as InitiativeRollData).resolvePromise({
+				roll: new Roll(formula, { symbols }),
+				skillName: selectedSkill.value?.name ?? 'Unskilled',
+			});
+			break;
+
+		default:
+			await GenesysRoller.skillRoll(baseRollData);
+	}
+
+	await context.app.close();
 }
 </script>
 
@@ -419,47 +527,63 @@ async function approximateProbability() {
 		<div class="preview">
 			<!-- Positive Pool -->
 			<div class="positive">
-				<div v-for="(dieName, index) in positiveDice" :key="index" @click="removeDie(dieName, index)" :class="`die die-${dieName}`">{{ DieType[dieName].GLYPH }}</div>
-				<div v-for="(symbolName, index) in positiveSymbols" :key="index" @click="removeSymbol(symbolName, index)" class="symbol">{{ GenesysSymbol[symbolName].GLYPH }}</div>
+				<template v-for="[dieName, amount] in getOrderedDice('positive')" :key="dieName">
+					<div v-for="index in amount" :key="`${dieName}-${index}`" @click="addDiceOperation(dieName as DieName, true)" :class="`die die-${dieName}`">
+						{{ GenesysDice[dieName as DieName].GLYPH }}
+					</div>
+				</template>
+				<template v-for="[symbolName, amount] in getOrderedSymbols('positive')" :key="symbolName">
+					<div v-for="index in amount" :key="`${symbolName}-${index}`" @click="addSymbolOperation(symbolName as SymbolName, true)" class="symbol">
+						{{ GenesysSymbol[symbolName as SymbolName].GLYPH }}
+					</div>
+				</template>
 			</div>
 
 			<!-- Negative Pool -->
 			<div class="negative">
-				<div v-for="(dieName, index) in negativeDice" :key="index" @click="removeDie(dieName, index)" :class="`die die-${dieName}`">{{ DieType[dieName].GLYPH }}</div>
-				<div v-for="(symbolName, index) in negativeSymbols" :key="index" @click="removeSymbol(symbolName, index)" class="symbol">{{ GenesysSymbol[symbolName].GLYPH }}</div>
+				<template v-for="[dieName, amount] in getOrderedDice('negative')" :key="dieName">
+					<div v-for="index in amount" :key="`${dieName}-${index}`" @click="addDiceOperation(dieName as DieName, true)" :class="`die die-${dieName}`">
+						{{ GenesysDice[dieName as DieName].GLYPH }}
+					</div>
+				</template>
+				<template v-for="[symbolName, amount] in getOrderedSymbols('negative')" :key="symbolName">
+					<div v-for="index in amount" :key="`${symbolName}-${index}`" @click="addSymbolOperation(symbolName as SymbolName, true)" class="symbol">
+						{{ GenesysSymbol[symbolName as SymbolName].GLYPH }}
+					</div>
+				</template>
 			</div>
 
 			<!-- Dice Box -->
 			<div class="dice-box">
 				<!-- Add Positive Dice -->
-				<a @click="addDie('Ability')" data-die="Ability">A<i class="fas fa-plus"></i></a>
-				<a @click="addDie('Proficiency')" data-die="Proficiency">P<i class="fas fa-plus"></i></a>
-				<a @click="addDie('Boost')" data-die="Boost">B<i class="fas fa-plus"></i></a>
+				<a @click="addDiceOperation('Ability')" data-die="Ability">A<i class="fas fa-plus"></i></a>
+				<a @click="addDiceOperation('Proficiency')" data-die="Proficiency">P<i class="fas fa-plus"></i></a>
+				<a @click="addDiceOperation('Boost')" data-die="Boost">B<i class="fas fa-plus"></i></a>
 
 				<!-- Upgrade/Downgrade Positive Dice -->
-				<a @click="upgradeDie('positive')" data-die="Ability">A<i class="fas fa-arrow-up"></i></a>
-				<a @click="downgradeDie('positive')" data-die="Proficiency">P<i class="fas fa-arrow-down"></i></a>
+				<a @click="addPoolOperation('UpgradeAbility')" data-die="Ability">A<i class="fas fa-arrow-up"></i></a>
+				<a @click="addPoolOperation('DowngradeAbility')" data-die="Proficiency">P<i class="fas fa-arrow-down"></i></a>
 				<span />
 
 				<!-- Add Negative Dice -->
-				<a @click="addDie('Difficulty')" data-die="Difficulty">D<i class="fas fa-plus"></i></a>
-				<a @click="addDie('Challenge')" data-die="Challenge">C<i class="fas fa-plus"></i></a>
-				<a @click="addDie('Setback')" data-die="Setback">S<i class="fas fa-plus"></i></a>
+				<a @click="addDiceOperation('Difficulty')" data-die="Difficulty">D<i class="fas fa-plus"></i></a>
+				<a @click="addDiceOperation('Challenge')" data-die="Challenge">C<i class="fas fa-plus"></i></a>
+				<a @click="addDiceOperation('Setback')" data-die="Setback">S<i class="fas fa-plus"></i></a>
 
 				<!-- Upgrade/Downgrade Negative Dice -->
-				<a @click="upgradeDie('negative')" data-die="Difficulty">D<i class="fas fa-arrow-up"></i></a>
-				<a @click="downgradeDie('negative')" data-die="Challenge">C<i class="fas fa-arrow-down"></i></a>
+				<a @click="addPoolOperation('UpgradeDifficulty')" data-die="Difficulty">D<i class="fas fa-arrow-up"></i></a>
+				<a @click="addPoolOperation('DowngradeDifficulty')" data-die="Challenge">C<i class="fas fa-arrow-down"></i></a>
 				<span />
 
 				<!-- Add Positive Symbols -->
-				<a @click="addSymbol('Advantage')">a<i class="fas fa-plus"></i></a>
-				<a @click="addSymbol('Success')">s<i class="fas fa-plus"></i></a>
-				<a @click="addSymbol('Triumph')">t<i class="fas fa-plus"></i></a>
+				<a @click="addSymbolOperation('Advantage')">a<i class="fas fa-plus"></i></a>
+				<a @click="addSymbolOperation('Success')">s<i class="fas fa-plus"></i></a>
+				<a @click="addSymbolOperation('Triumph')">t<i class="fas fa-plus"></i></a>
 
 				<!-- Add Negative Symbols -->
-				<a @click="addSymbol('Threat')">h<i class="fas fa-plus"></i></a>
-				<a @click="addSymbol('Failure')">f<i class="fas fa-plus"></i></a>
-				<a @click="addSymbol('Despair')">d<i class="fas fa-plus"></i></a>
+				<a @click="addSymbolOperation('Threat')">h<i class="fas fa-plus"></i></a>
+				<a @click="addSymbolOperation('Failure')">f<i class="fas fa-plus"></i></a>
+				<a @click="addSymbolOperation('Despair')">d<i class="fas fa-plus"></i></a>
 			</div>
 		</div>
 
@@ -480,6 +604,43 @@ async function approximateProbability() {
 		<div v-else-if="USE_SUPER_CHARACTERISTICS" class="super-characteristic-row">
 			<input type="checkbox" v-model="useSuperCharacteristic" />
 			<label><Localized label="Genesys.DicePrompt.UseSuperCharacteristic" /></label>
+		</div>
+
+		<div class="pool-modifications-title" @click="showPoolModifications = !showPoolModifications">
+			<i :class="`fas fa-caret-${showPoolModifications ? 'down' : 'right'}`"></i>
+			<span><Localized label="Genesys.DicePrompt.PoolModifications.Title" /></span>
+		</div>
+
+		<div :class="{ 'pool-modifications-expander': true, 'pool-modifications-expanded': showPoolModifications }">
+			<div class="pool-modifications-container">
+				<div>
+					<span><Localized label="Genesys.DicePrompt.PoolModifications.DefaultDifficulty" /></span>
+					<div>
+						<a v-for="(modification, index) in poolModifications.baseDifficulty" :key="index" :data-die="POOL_MODIFICATIONS_DATA[modification].icon.baseName">
+							{{ POOL_MODIFICATIONS_DATA[modification].icon.baseGlyph }}<i :class="`fas ${POOL_MODIFICATIONS_DATA[modification].icon.operator}`"></i>
+						</a>
+					</div>
+				</div>
+				<div class="pool-modifications-manual">
+					<span><Localized label="Genesys.DicePrompt.PoolModifications.ManualChanges" /></span>
+					<div>
+						<a v-for="(modification, index) in poolModifications.manualChanges" :key="index" @click="removeManualChange(index)" :data-die="POOL_MODIFICATIONS_DATA[modification].icon.baseName">
+							{{ POOL_MODIFICATIONS_DATA[modification].icon.baseGlyph }}<i :class="`fas ${POOL_MODIFICATIONS_DATA[modification].icon.operator}`"></i>
+						</a>
+					</div>
+				</div>
+				<div v-for="(effect, index) in poolModifications.effects" :key="index" class="pool-modifications-effects">
+					<span>
+						<input type="checkbox" v-model="effect.enabled" @change="buildDicePool()" />
+						<label>{{ '\xa0' + effect.name }}</label>
+					</span>
+					<div>
+						<a v-for="(modification, index) in effect.mods" :key="index" :data-die="POOL_MODIFICATIONS_DATA[modification].icon.baseName">
+							{{ POOL_MODIFICATIONS_DATA[modification].icon.baseGlyph }}<i :class="`fas ${POOL_MODIFICATIONS_DATA[modification].icon.operator}`"></i>
+						</a>
+					</div>
+				</div>
+			</div>
 		</div>
 
 		<div v-if="USE_CHANCE_TO_SUCCEED" class="chance-to-succeed">
@@ -514,11 +675,12 @@ async function approximateProbability() {
 <style lang="scss" scoped>
 @use '@scss/vars/colors.scss';
 @use '@scss/vars/sheet.scss';
+@use '@scss/mixins/reset.scss';
 
 .dice-prompt {
 	display: grid;
 	grid-template-columns: 2fr 1fr 2fr;
-	grid-template-rows: /* Header */ auto /* Dice Pool */ 1fr /* Skill & Characteristic */ auto /* Roll Button */ auto;
+	grid-template-rows: /* Header */ auto /* Dice Pool */ 1fr /* Skill & Characteristic */ auto;
 	gap: 0.5em;
 
 	//#region Grid Layout
@@ -532,7 +694,6 @@ async function approximateProbability() {
 		.hint {
 			font-family: 'Roboto', serif;
 			font-size: 1rem;
-			// color: colors.$dark-blue;
 		}
 	}
 
@@ -567,9 +728,133 @@ async function approximateProbability() {
 		}
 	}
 
+	.pool-modifications-title {
+		grid-column: 1 / span all;
+		grid-row: 4 / span all;
+		display: grid;
+		grid-template-columns: 1rem 1fr;
+		font-family: 'Bebas Neue', sans-serif;
+		font-size: 1.2rem;
+		margin-bottom: -0.5em;
+	}
+
+	.pool-modifications-expander {
+		grid-column: 1 / span all;
+		grid-row: 5 / span all;
+		display: grid;
+		grid-template-rows: 0fr;
+		overflow: hidden;
+		transition: grid-template-rows 1s;
+
+		&.pool-modifications-expanded {
+			grid-template-rows: 1fr;
+
+			.pool-modifications-container {
+				visibility: visible;
+			}
+		}
+	}
+
+	.pool-modifications-container {
+		display: grid;
+		font-family: 'Roboto', sans-serif;
+		margin-left: 1rem;
+		border-top: 1px dotted black;
+
+		min-height: 0;
+		transition: visibility 1s;
+		visibility: hidden;
+
+		& > div {
+			display: grid;
+			grid-template-columns: 1fr 2fr;
+			border-bottom: 1px dotted black;
+			min-height: 1.2rem;
+
+			& > span {
+				padding-right: 4px;
+			}
+
+			& > div {
+				border-left: 1px dotted black;
+				padding-left: 0.5rem;
+
+				a {
+					position: relative;
+					top: 3px;
+				}
+			}
+		}
+
+		a {
+			display: inline-flex;
+			flex-direction: row;
+			flex-wrap: nowrap;
+			align-items: flex-start;
+			font-family: 'Genesys Symbols', sans-serif;
+			margin-right: 0.2rem;
+			cursor: default;
+
+			&[data-die] {
+				-webkit-text-stroke: 0.5px black;
+				text-stroke: 0.5px black;
+
+				i {
+					-webkit-text-stroke: 0 transparent;
+					text-stroke: 0 transparent;
+				}
+			}
+
+			&[data-die='Ability'] {
+				color: colors.$die-ability;
+			}
+
+			&[data-die='Proficiency'] {
+				color: colors.$die-proficiency;
+			}
+
+			&[data-die='Boost'] {
+				color: colors.$die-boost;
+			}
+
+			&[data-die='Difficulty'] {
+				color: colors.$die-difficulty;
+			}
+
+			&[data-die='Challenge'] {
+				color: colors.$die-challenge;
+			}
+
+			&[data-die='Setback'] {
+				color: colors.$die-setback;
+			}
+		}
+
+		i {
+			color: black;
+			position: relative;
+			font-size: 0.5em;
+			top: -0.25em;
+		}
+
+		.pool-modifications-manual {
+			a {
+				cursor: pointer;
+			}
+		}
+
+		.pool-modifications-effects {
+			@include reset.input;
+			input {
+				height: 1em;
+			}
+		}
+	}
+
 	.chance-to-succeed {
 		grid-column: 1 / span 2;
-		grid-row: 4 / span 1;
+		grid-row: 6 / span 1;
+		margin-top: 1rem;
 
 		label {
 			margin-right: 1rem;
@@ -578,7 +863,8 @@ async function approximateProbability() {
 
 	.roll-button {
 		grid-column: 3 / span 1;
-		grid-row: 4 / span 1;
+		grid-row: 6 / span 1;
+		margin-top: 1rem;
 	}
 	//#endregion
 

--- a/src/vue/sheets/actor/character/CombatTab.vue
+++ b/src/vue/sheets/actor/character/CombatTab.vue
@@ -21,12 +21,13 @@ const weapons = computed(() => toRaw(rootContext.data.actor).items.filter((i) =>
 const armors = computed(() => toRaw(rootContext.data.actor).items.filter((i) => i.type === 'armor' && i.system.state === 'equipped') as GenesysItem<ArmorDataModel>[]);
 const injuries = computed(() => toRaw(rootContext.data.actor).items.filter((i) => i.type === 'injury') as GenesysItem<InjuryDataModel>[]);
 
-const SEVERITY_TO_DIFFICULTY = {
-	'-': 0,
-	easy: 1,
-	average: 2,
-	hard: 3,
-	daunting: 4,
+const SEVERITY_TO_DIFFICULTY: Record<InjuryDataModel['severity'], string> = {
+	'-': 'D'.repeat(0),
+	easy: 'D'.repeat(1),
+	average: 'D'.repeat(2),
+	hard: 'D'.repeat(3),
+	daunting: 'D'.repeat(4),
+	formidable: 'D'.repeat(5),
 };
 
 async function openItem(item: GenesysItem) {

--- a/src/vue/sheets/actor/vehicle/CombatTab.vue
+++ b/src/vue/sheets/actor/vehicle/CombatTab.vue
@@ -23,12 +23,13 @@ const actor = computed(() => toRaw(rootContext.data.actor));
 const weapons = computed(() => toRaw(rootContext.data.actor).items.filter((i) => i.type === 'vehicleWeapon' && i.system.state === EquipmentState.Equipped) as GenesysItem<VehicleWeaponDataModel>[]);
 const criticalHits = computed(() => toRaw(rootContext.data.actor).items.filter((i) => i.type === 'injury') as GenesysItem<InjuryDataModel>[]);
 
-const SEVERITY_TO_DIFFICULTY: Record<InjuryDataModel['severity'], number> = {
-	'-': 0,
-	easy: 1,
-	average: 2,
-	hard: 3,
-	daunting: 4,
+const SEVERITY_TO_DIFFICULTY: Record<InjuryDataModel['severity'], string> = {
+	'-': 'D'.repeat(0),
+	easy: 'D'.repeat(1),
+	average: 'D'.repeat(2),
+	hard: 'D'.repeat(3),
+	daunting: 'D'.repeat(4),
+	formidable: 'D'.repeat(5),
 };
 
 function getFiringArcLabels(weapon: GenesysItem<VehicleWeaponDataModel>) {

--- a/src/vue/sheets/item/InjurySheet.vue
+++ b/src/vue/sheets/item/InjurySheet.vue
@@ -23,6 +23,7 @@ const system = computed(() => context.data.item.systemData);
 						<option value="average"><Localized label="Genesys.Difficulty.Average" /></option>
 						<option value="hard"><Localized label="Genesys.Difficulty.Hard" /></option>
 						<option value="daunting"><Localized label="Genesys.Difficulty.Daunting" /></option>
+						<option value="formidable"><Localized label="Genesys.Difficulty.Formidable" /></option>
 					</select>
 				</div>
 

--- a/types/foundry/client/application/form-application/document-sheet/active-effect-config.d.ts
+++ b/types/foundry/client/application/form-application/document-sheet/active-effect-config.d.ts
@@ -12,6 +12,7 @@ declare global {
 
 	interface ActiveEffectConfigData<TDocument extends ActiveEffect = ActiveEffect> extends DocumentSheetData<TDocument> {
 		effect: TDocument;
+		data: TDocument;
 		isActorEffect: boolean;
 		isItemEffect: boolean;
 		submitText: string;
@@ -23,7 +24,7 @@ declare global {
 		static get defaultOptions(): ActiveEffectConfigOptions;
 
 		/** @override */
-		getData(options?: DocumentSheetOptions): ActiveEffectConfigData<TDocument>;
+		getData(options?: DocumentSheetOptions): ActiveEffectConfigData<TDocument> | Promise<ActiveEffectConfigData<TDocument>>;
 
 		/**
 		 * Provide centralized handling of mouse clicks on control buttons.

--- a/types/foundry/client/core/hooks.d.ts
+++ b/types/foundry/client/core/hooks.d.ts
@@ -57,6 +57,7 @@ declare global {
 		static on(...args: HookParamsRender<ItemDirectory<Item>, 'ItemDirectory'>): number;
 		static on(...args: HookParamsRender<SceneControls, 'SceneControls'>): number;
 		static on(...args: HookParamsRender<Settings, 'Settings'>): number;
+		static on(...args: HookParamsRender<SettingsConfig, 'SettingsConfig'>): number;
 		static on(...args: HookParamsRender<TokenHUD, 'TokenHUD'>): number;
 		static on(...args: HookParamsRender<JournalPageSheet, 'JournalPageSheet'>): number;
 		static on(...args: HookParamsRender<JournalTextPageSheet, 'JournalTextPageSheet'>): number;
@@ -99,6 +100,7 @@ declare global {
 		static once(...args: HookParamsRender<JournalTextPageSheet, 'JournalTextPageSheet'>): number;
 		static once(...args: HookParamsRender<SceneControls, 'SceneControls'>): number;
 		static once(...args: HookParamsRender<Settings, 'Settings'>): number;
+		static once(...args: HookParamsRender<SettingsConfig, 'SettingsConfig'>): number;
 		static once(...args: HookParamsRender<TokenHUD, 'TokenHUD'>): number;
 		static once(...args: HookParamsRender<SidebarTab, 'SidebarTab'>): number;
 		static once(...args: HookParamsTargetToken): number;

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -33,6 +33,10 @@ Genesys:
   Settings:
     SkillsCompendium: Skills Compendium
     SkillsCompendiumHint: An Item compendium containing all of the skills that should be applied to new characters. Changing this value will have no impact on existing characters.
+    DefaultDifficulty: Default Difficulty
+    DefaultDifficultyHint: >-
+      The default dice pool modifications that should be added to the dice pool when doing a check. This default might be ignored in cases were the difficulty is known.
+      For an explanation of all the possible modifications and their glyph please check [[Dice-Pool-Modification-Glyphs|Dice Pool Modification Glyphs]].
     Money: Currency Label
     MoneyHint: The name (such as Gold, Credits, Cash, Doubloons, etc) used for Currency in the system.
     CareerSkillRanks: Career Skill Ranks
@@ -47,6 +51,10 @@ Genesys:
     SkillForRepairingVehicleHitsHint: Name of the skill used when recovering from Critical Hits.
     UseMagicalGirlSymbols: Use Magical Girl Symbols by MilkMyth (Client-Only)
     UseMagicalGirlSymbolsHint: Swap the Genesys symbol set for MilkMyth's Magical Girls symbol set. This will not affect other users.
+    DicePoolCollapseModifications: Collapse the Pool Modifications Section
+    DicePoolCollapseModificationsHint: If enabled the 'Pool Modifications' section on the dice pool prompt will be collapsed during the initial render.
+    DicePoolAutoApplyModifications: Auto-Apply Pool Modifications
+    DicePoolAutoApplyModificationsHint: If enabled all the modifications that can affect the dice pool will be applied when opening the dice pool prompt.
     DicePoolChanceToSucceedByPermutation: Calculate the Chance to Succeed for Dice Pools
     DicePoolChanceToSucceedByPermutationHint: >-
       If enabled this will spawn a Web Worker that calculates the exact chance to succeed.
@@ -121,6 +129,7 @@ Genesys:
     Average: Average
     Hard: Hard
     Daunting: Daunting
+    Formidable: Formidable
     Impossible: Impossible
 
   Inventory:
@@ -142,7 +151,10 @@ Genesys:
       ModifyCharacteristic: Modify Characteristic
       ModifyStat: Modify Stat
       ModifySkill: Modify Skill
-      ModifyDicePool: Modify Dice Pool
+      ModifyDicePool:
+        GroupLabel: Modify Dice Pool
+        Options:
+          Skill: Skill Dice Pool
 
   # Dice Prompt Labels
   DicePrompt:
@@ -150,6 +162,10 @@ Genesys:
     Roll: Roll!
     Hint: Use the dice box on the right to add, upgrade, and downgrade. Click dice in the pool to remove them!
     UseSuperCharacteristic: Roll as a super-characteristic
+    PoolModifications:
+      Title: Pool Modifications
+      DefaultDifficulty: Default Difficulty
+      ManualChanges: Manual Changes
     ChanceToSucceed: 'Chance to Succeed:'
     ChanceToSucceedByPermutationDisclaimer: The displayed probability is exact unless the dice pool includes a super-characteristic.
     ChanceToSucceedBySimulationDisclaimer: The displayed probability is an approximation that uses the Monte Carlo method.
@@ -244,6 +260,7 @@ Genesys:
   # Localized strings used in TextEditor enrichers.
   Enrichers:
     Difficulty: '{difficulty} [{symbols}] {skill} check'  # e.g. Average [♦♦] Coercion Check
+    Opposed: 'Opposed {skill1} versus {skill2} check'
 
   # Combat Tracker
   CombatTracker:

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -33,6 +33,10 @@ Genesys:
   Settings:
     SkillsCompendium: Compendium des Compétences
     SkillsCompendiumHint: "Un compenduim d'item contenant l'ensemble des compétences qui peut être ajouter à un nouveau personnage. Changer cette valeur n'a pas d'effet rétroactif sur les anciens personnages."
+    DefaultDifficulty: Default Difficulty
+    DefaultDifficultyHint: >-
+      The default dice pool modifications that should be added to the dice pool when doing a check. This default might be ignored in cases were the difficulty is known.
+      For an explanation of all the possible modifications and their glyph please check [[Dice-Pool-Modification-Glyphs|Dice Pool Modification Glyphs]].
     Money: Monnaie
     MoneyHint: "Le nom de la monaie (comme l'or, les crédits, le Cash, les Doublons, etc) utiliser pour l'argent du système."
     CareerSkillRanks: Nombre de Compétence de Carrière
@@ -47,6 +51,10 @@ Genesys:
     SkillForRepairingVehicleHitsHint: Nom de la compétence utilisée pour récupérer des dommages critiques.
     UseMagicalGirlSymbols: Utilise le symbole Magical Girls pour MilkMyth (Utilisateur seulement)
     UseMagicalGirlSymbolsHint: "Remplacer le jeu de symboles Genesys par le jeu de symboles Magical Girls de MilkMyth. Cela n'affectera pas les autres utilisateurs."
+    DicePoolCollapseModifications: Collapse the Pool Modifications Section
+    DicePoolCollapseModificationsHint: If enabled the 'Pool Modifications' section on the dice pool prompt will be collapsed during the initial render.
+    DicePoolAutoApplyModifications: Auto-Apply Pool Modifications
+    DicePoolAutoApplyModificationsHint: If enabled all the modifications that can affect the dice pool will be applied when opening the dice pool prompt.
     DicePoolChanceToSucceedByPermutation: Calcul les chances de succès pour ce pool.
     DicePoolChanceToSucceedByPermutationHint: >-
       Si cette option est activée, elle génère un Web Worker qui calcule les chances exactes de réussite.
@@ -121,6 +129,7 @@ Genesys:
     Average: Moyen
     Hard: Difficile
     Daunting: Intimidant
+    Formidable: Formidable
     Impossible: Impossible
 
   Inventory:
@@ -142,7 +151,10 @@ Genesys:
       ModifyCharacteristic: Caractérisitique à Modifier
       ModifyStat: Statistique à Modifier
       ModifySkill: Compétence à Modifier
-      ModifyDicePool: Réserve de Dés à Modifier
+      ModifyDicePool:
+        GroupLabel: Réserve de Dés à Modifier
+        Options:
+          Skill: Skill Dice Pool
 
   # Dice Prompt Labels
   DicePrompt:
@@ -150,6 +162,10 @@ Genesys:
     Roll: Jet!
     Hint: Utilisez la boîte à dés sur la droite pour ajouter, améliorer et rétrograder. Cliquez sur les dés dans la réserve pour les retirer!
     UseSuperCharacteristic: Utiliser comme une super-Caractérisique
+    PoolModifications:
+      Title: Pool Modifications
+      DefaultDifficulty: Default Difficulty
+      ManualChanges: Manual Changes
     ChanceToSucceed: 'Chance de réussite:'
     ChanceToSucceedByPermutationDisclaimer: "Affiche la probabilité exacte à moins qu'un dé dans le pool soit une super-caractéristique."
     ChanceToSucceedBySimulationDisclaimer: La probabilité affiché est une approximation caculé à partir de la méthode de Monte Carlo.
@@ -243,6 +259,7 @@ Genesys:
   # Localized strings used in TextEditor enrichers.
   Enrichers:
     Difficulty: 'Test de {skill} contre {difficulty} [{symbols}]'  # e.g. Average [♦♦] Coercion Check
+    Opposed: 'Opposed {skill1} versus {skill2} check'
 
   # Combat Tracker
   CombatTracker:


### PR DESCRIPTION
This PR adds support for dice pool modifications tied to skills. This is done via active effects by using a special syntax for the "value" field. More details about the what is considered valid can be found on the wiki [Dice Pool Modification Glyphs](https://github.com/Mezryss/FVTT-Genesys/wiki/Dice-Pool-Modification-Glyphs).

## Changes
- There's a new setting that lets the GM set a default difficulty. Before this PR the difficulty was assumed to be two difficulty dice except on special occasions (no difficulty for initiative and a set difficulty when healing a critical injury).
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/066c35b0-ab6a-4c81-b180-73cc858958a7)

- Users can now add active effect changes that can modify the dice pool when a specific skill is selected.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/16b1aaf9-b4c2-4d40-874b-6c6a739e3544)

- There is a new section on the "Dice Pool" prompt that shows all the dice pool modifications that are active at the moment. The "Default Difficulty" is taken either from the setting mentioned above or from the provided context. "Manual Changes" are all the modifications done by the user to the pool by clicking the icons on the preview area. If you want to remove one of these modifications simply click on the appropriate icon; this only works for the "Manual Changes" row. After that you'll see one row per each active effect that is targeting the selected skill. The checkbox to the left can be used to enable/disable the modifications.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/4a7029b6-9c0d-4ef7-b10f-d559cb84001f)

- There are two new user settings: one to collapse the "Pool Modifications" section when rendering the dice prompt and one for automatically enabling all the modifications.
![image](https://github.com/Mezryss/FVTT-Genesys/assets/1728535/e18b4224-da8d-4ede-8dd1-d19e0083e260)

## Limitations
- You might notice that the dice pool modifications behave a little differently from what's expected when compared to modifications to stats for ranked talents. Typically a numeric active effect change is applied a number of times equal to the ranks of the talent that has it. However, this is not the case if the change is a dice pool modification; those are applied only once. This behavior is intentional after looking at ranked talents that do dice pool modifications. In the future, when I get to refactor the whole codebase, I'll allow for a way to specify if a change should be influenced by the rank or not.

_Note: Implements #53_ 