### PR TITLE
Enhance enrichers

### DIFF
--- a/src/dice/types/GenesysPoolModifications.ts
+++ b/src/dice/types/GenesysPoolModifications.ts
@@ -1,0 +1,81 @@
+import { GenesysDice } from '@/dice';
+import { GenesysPoolGradeOperation } from '@/dice/types/GenesysPoolGradeOperation';
+import { GenesysSymbol } from '@/dice/types/GenesysSymbol';
+
+type PoolEntity = keyof typeof GenesysDice | keyof typeof GenesysSymbol | keyof typeof GenesysPoolGradeOperation;
+
+type PoolModificationData = {
+	targetName: PoolEntity;
+	icon: { baseType: 'dice' | 'symbol'; baseName: string; baseGlyph: string; operator: string };
+	sort: number;
+};
+
+// A pattern for glyphs that represent all the possible pool modifications.
+export const PoolModGlyphPattern = /(-?[BAPSDCasthfd]|[\^*_~])/g;
+
+export const GenesysPoolModifications: Record<string, PoolModificationData> = Object.fromEntries([
+	...Object.entries(GenesysDice).map(([dieName, dieType]) => [
+		dieType.GLYPH,
+		{
+			targetName: dieName,
+			icon: { baseType: 'dice', baseName: dieName, baseGlyph: dieType.GLYPH, operator: 'fa-plus' },
+			sort: 0,
+		},
+	]),
+	[
+		GenesysPoolGradeOperation.UpgradeAbility.GLYPH,
+		{
+			targetName: 'UpgradeAbility',
+			icon: { baseType: 'dice', baseName: 'Ability', baseGlyph: GenesysDice['Ability'].GLYPH, operator: 'fa-arrow-up' },
+			sort: 1,
+		},
+	],
+	[
+		GenesysPoolGradeOperation.UpgradeDifficulty.GLYPH,
+		{
+			targetName: 'UpgradeDifficulty',
+			icon: { baseType: 'dice', baseName: 'Difficulty', baseGlyph: GenesysDice['Difficulty'].GLYPH, operator: 'fa-arrow-up' },
+			sort: 1,
+		},
+	],
+	[
+		GenesysPoolGradeOperation.DowngradeAbility.GLYPH,
+		{
+			targetName: 'DowngradeAbility',
+			icon: { baseType: 'dice', baseName: 'Proficiency', baseGlyph: GenesysDice['Proficiency'].GLYPH, operator: 'fa-arrow-down' },
+			sort: 2,
+		},
+	],
+	[
+		GenesysPoolGradeOperation.DowngradeDifficulty.GLYPH,
+		{
+			targetName: 'DowngradeDifficulty',
+			icon: { baseType: 'dice', baseName: 'Challenge', baseGlyph: GenesysDice['Challenge'].GLYPH, operator: 'fa-arrow-down' },
+			sort: 2,
+		},
+	],
+	...Object.entries(GenesysDice).map(([dieName, dieType]) => [
+		`-${dieType.GLYPH}`,
+		{
+			targetName: dieName,
+			icon: { baseType: 'dice', baseName: dieName, baseGlyph: dieType.GLYPH, operator: 'fa-minus' },
+			sort: 3,
+		},
+	]),
+	...Object.entries(GenesysSymbol).map(([symbolName, symbolType]) => [
+		symbolType.GLYPH,
+		{
+			targetName: symbolName,
+			icon: { baseType: 'symbol', baseName: symbolName, baseGlyph: symbolType.GLYPH, operator: 'fa-plus' },
+			sort: 4,
+		},
+	]),
+	...Object.entries(GenesysSymbol).map(([symbolName, symbolType]) => [
+		`-${symbolType.GLYPH}`,
+		{
+			targetName: symbolName,
+			icon: { baseType: 'symbol', baseName: symbolName, baseGlyph: symbolType.GLYPH, operator: 'fa-minus' },
+			sort: 5,
+		},
+	]),
+]);

--- a/src/effects/GenesysEffect.ts
+++ b/src/effects/GenesysEffect.ts
@@ -18,9 +18,6 @@ export default class GenesysEffect extends ActiveEffect {
 	// skill.
 	static DICE_POOL_MOD_SKILL_PREFIX = 'genesys.pool.skill';
 
-	// The value of an effect that modifies the dice pool must be composed of 'tokens' that followe this pattern.
-	static DICE_POOL_MOD_SKILL_PATTERN = /(-?[BAPSDCasthfd]|[\^*_~])/g;
-
 	get originItem(): GenesysItem | undefined {
 		if (!this.origin || !(this.parent instanceof GenesysActor) || !this.origin.includes('.Item.')) {
 			return undefined;

--- a/src/effects/GenesysEffectSheet.ts
+++ b/src/effects/GenesysEffectSheet.ts
@@ -7,6 +7,7 @@
  */
 
 import GenesysEffect from '@/effects/GenesysEffect';
+import { PoolModGlyphPattern } from '@/dice/types/GenesysPoolModifications';
 import './GenesysEffectSheet.scss';
 
 type EffectChangeExpanded = foundry.data.EffectChangeSource & {
@@ -104,7 +105,7 @@ export default class GenesysEffectSheet extends ActiveEffectConfig<GenesysEffect
 	}
 
 	protected override _getSubmitData(updateData?: Record<string, unknown>) {
-		const dicePoolModificationPattern = new RegExp(`^${GenesysEffect.DICE_POOL_MOD_SKILL_PATTERN.source}*$`);
+		const dicePoolModificationPattern = new RegExp(`^${PoolModGlyphPattern.source}*$`);
 		const submitData = super._getSubmitData(updateData) as IncompleteSheetSubmitData;
 
 		// Loop through all the changes and make sure to construct the proper key for those that deal with dice pool

--- a/src/enrichers.ts
+++ b/src/enrichers.ts
@@ -5,139 +5,184 @@
  * @author Mezryss
  * @file TextEditor enrichment methods
  */
+import { GenesysDice } from '@/dice';
+import { GenesysPoolModifications, PoolModGlyphPattern } from '@/dice/types/GenesysPoolModifications';
 
-const DICE_COLOR_TO_SYMBOL: Record<string, string> = {
-	G: 'A', // Ability
-	Y: 'P', // Proficiency
-	B: 'B', // Boost
-	P: 'D', // Difficulty
-	R: 'C', // Challenge
-	K: 'S', // Setback
-};
+const DICE_COLOR_TO_GLYPH = Object.fromEntries(
+	Object.values(GenesysDice).map((die) => {
+		return [die.COLOR, die.GLYPH];
+	}),
+);
 
 export function register() {
-	CONFIG.TextEditor.enrichers = [
-		...CONFIG.TextEditor.enrichers,
+	/**
+	 * Enricher to easily add Genesys dice into the document.
+	 *
+	 * The string accepts any of the following characters, ignoring case sensitivity.
+	 *    Ability Die => normal: A, color: G
+	 *    Proficiency Die => normal: P, color: Y
+	 *    Boost Die => normal: B, color: B
+	 *    Difficulty Die => normal: D or I, color: P
+	 *    Challenge Die => normal: C, color: R
+	 *    Setback Die => normal: S, color: K
+	 */
+	CONFIG.TextEditor.enrichers.push({
+		pattern: /@dic?e\[(col(or)?s?,(?<colors>[GYBPRK]+)|(?<dice>[APBDICS]+))]/gim,
+		enricher: async (match, _) => {
+			let dice = match.groups?.['dice']?.toUpperCase().split('');
 
-		/**
-		 * Enricher to easily add Genesys dice into the document.
-		 *
-		 * Dice string accept any of the following characters (case-insensitive):
-		 *  A: Ability Die
-		 *  P: Proficiency Die
-		 *  B: Boost Die
-		 *  D or I: Difficulty Die
-		 *  C: Challenge Die
-		 *  S: Setback Die
-		 */
-		{
-			pattern: /@dic?e\[(col(or)?s?,(?<colors>[GYBPRK]+)|(?<dice>[APBDICS]+))]/gim,
-			enricher: async (match, _) => {
-				const container = document.createElement('span');
-				container.className = 'font-genesys-symbols';
+			const colors = match.groups?.['colors']?.toUpperCase().split('');
+			if (colors) {
+				dice = colors.map((c) => DICE_COLOR_TO_GLYPH[c] ?? '');
+			}
 
-				const colors = match.groups?.['colors']?.toUpperCase();
-				let dice = match.groups?.['dice']?.toUpperCase();
-				if (!colors && !dice) {
-					return null;
+			if (!dice || dice.length === 0) {
+				return null;
+			}
+
+			const container = document.createElement('span');
+			container.className = 'font-genesys-symbols';
+
+			for (let die of dice) {
+				// Account for both possible annotations for difficulty dice.
+				if (die === 'I') {
+					die = 'D';
 				}
 
-				if (colors) {
-					dice = colors
-						.split('')
-						.map((c) => DICE_COLOR_TO_SYMBOL[c] ?? '')
-						.join('');
-				}
+				const newI = document.createElement('i');
+				newI.className = `die die-${die}`;
+				newI.innerText = die;
 
-				// Past this point it's safe to assume dice exists.
-				dice = dice!;
+				container.appendChild(newI);
+			}
 
-				for (let die of dice.split('')) {
-					// Account for both possible annotations for difficulty dice.
-					if (die === 'I') {
-						die = 'D';
-					}
-
-					const i = document.createElement('i');
-					i.className = `die die-${die}`;
-					i.innerText = die;
-
-					container.appendChild(i);
-				}
-
-				return container;
-			},
+			return container;
 		},
+	});
 
-		/**
-		 * Enricher to easily add Genesys symbols into the document.
-		 */
-		{
-			pattern: /@sym(bols?)?\[(?<symbols>\w+)]/gim,
-			enricher: async (match, _) => {
-				const span = document.createElement('span');
-				span.className = `font-genesys-symbols nolig ${CONFIG.genesys.settings.useMagicalGirlSymbols ? 'mg' : ''}`;
+	/**
+	 * Enricher to easily add Genesys symbols into the document.
+	 */
+	CONFIG.TextEditor.enrichers.push({
+		pattern: /@sym(bols?)?\[(?<symbols>[asthfd123]+)]/gim,
+		enricher: async (match, _) => {
+			const newSpan = document.createElement('span');
+			newSpan.className = `font-genesys-symbols nolig ${CONFIG.genesys.settings.useMagicalGirlSymbols ? 'mg' : ''}`;
+			newSpan.innerText = match.groups?.['symbols']?.toLowerCase() ?? '';
 
-				span.innerText = match.groups?.['symbols']?.toLowerCase() ?? '';
-
-				return span;
-			},
+			return newSpan;
 		},
+	});
 
-		/**
-		 * Enricher to add skill check links in the document.
-		 */
-		{
-			pattern: /@skill-check\[(?<skill>.+?),(?<difficulty>\d)]/gim,
-			enricher: async (match, _) => {
-				const skill = match.groups?.['skill'];
-				const difficultyString = <string | undefined>match.groups?.['difficulty'];
-				if (!skill) {
-					return null;
-				}
+	/**
+	 * Enricher to add opposed skill check links in the document.
+	 */
+	CONFIG.TextEditor.enrichers.push({
+		pattern: /@(skill-)?check\[(?<skill1>[^|\]]+?)\|(?<skill2>[^|\]]+?)]/gim,
+		enricher: async (match, _) => {
+			const skill1 = match.groups?.['skill1'];
+			const skill2 = match.groups?.['skill2'];
+			if (!skill1 || !skill2) {
+				return null;
+			}
 
-				let difficulty = parseInt(difficultyString ?? '2');
-				let difficultyName: string;
+			const container = document.createElement('a');
+			container.style.fontWeight = 'bold';
 
-				switch (difficulty) {
-					case 0:
-						difficultyName = 'Simple';
-						break;
-					case 1:
-						difficultyName = 'Easy';
-						break;
-					case 2:
-						difficultyName = 'Average';
-						break;
-					case 3:
-						difficultyName = 'Hard';
-						break;
-					case 4:
-						difficultyName = 'Daunting';
-						break;
-					case 5:
-						difficultyName = 'Formidable';
-						break;
-					default:
-						difficultyName = 'Impossible';
-						difficulty = 5;
-				}
+			container.innerHTML =
+				'<i class="far fa-dice-d10"></i> ' +
+				game.i18n.format('Genesys.Enrichers.Opposed', {
+					skill1: skill1,
+					skill2: skill2,
+				});
 
-				const container = document.createElement('a');
-				container.style.fontWeight = 'bold';
-				container.dataset.skillCheck = skill;
-				container.dataset.difficulty = difficulty.toString();
-
-				container.innerHTML =
-					'<i class="far fa-dice-d10"></i> ' +
-					game.i18n.format('Genesys.Enrichers.Difficulty', {
-						difficulty: difficultyName,
-						symbols: `<span class="die die-D">${new Array(difficulty).fill('D').join('')}</span>`,
-						skill,
-					});
-
-				return container;
-			},
+			return container;
 		},
-	];
+	});
+
+	/**
+	 * Enricher to add skill check links in the document.
+	 */
+	CONFIG.TextEditor.enrichers.push({
+		pattern: /@(skill-)?check\[(?<skill>[^,\]|]+?)(,(?<difficulty>\d+)(\^(?<upgrades>\d+))?)?]/gim,
+		enricher: async (match, _) => {
+			const skill = match.groups?.['skill'];
+			if (!skill) {
+				return null;
+			}
+
+			let difficulty = parseInt(match.groups?.['difficulty'] ?? '2', 10);
+			const upgrades = Math.min(parseInt(match.groups?.['upgrades'] ?? '0', 10), difficulty);
+
+			let difficultyName: string;
+			switch (difficulty) {
+				case 0:
+					difficultyName = 'Simple';
+					break;
+				case 1:
+					difficultyName = 'Easy';
+					break;
+				case 2:
+					difficultyName = 'Average';
+					break;
+				case 3:
+					difficultyName = 'Hard';
+					break;
+				case 4:
+					difficultyName = 'Daunting';
+					break;
+				case 5:
+					difficultyName = 'Formidable';
+					break;
+				default:
+					difficultyName = 'Impossible';
+					difficulty = 5;
+			}
+			difficultyName = game.i18n.localize(`Genesys.Difficulty.${difficultyName}`);
+
+			const difficultyIcons = '<span class="die die-C">C</span>'.repeat(upgrades) + '<span class="die die-D">D</span>'.repeat(difficulty - upgrades);
+
+			const container = document.createElement('a');
+			container.style.fontWeight = 'bold';
+			container.dataset.skillCheck = skill;
+			container.dataset.difficulty = 'C'.repeat(upgrades) + 'D'.repeat(difficulty - upgrades);
+
+			container.innerHTML =
+				'<i class="far fa-dice-d10"></i> ' +
+				game.i18n.format('Genesys.Enrichers.Difficulty', {
+					difficulty: difficultyName,
+					symbols: difficultyIcons,
+					skill,
+				});
+
+			return container;
+		},
+	});
+
+	/**
+	 * Enricher to add pool modifications icons into a document.
+	 */
+	CONFIG.TextEditor.enrichers.push({
+		pattern: new RegExp(`@pool(-mod(ifications?)?)?\\[(?<mods>${PoolModGlyphPattern.source}+)]`, 'gim'),
+		enricher: async (match, _) => {
+			const mods: string[] = match.groups?.['mods']?.match(PoolModGlyphPattern)?.sort((left, right) => GenesysPoolModifications[left].sort - GenesysPoolModifications[right].sort) ?? [];
+
+			const container = document.createElement('span');
+			container.className = 'font-genesys-symbols pool-modifications';
+
+			for (const mod of mods) {
+				const newIDie = document.createElement('i');
+				newIDie.className = GenesysPoolModifications[mod].icon.baseType === 'dice' ? `die die-${GenesysPoolModifications[mod].icon.baseName}` : 'symbol';
+				newIDie.innerText = GenesysPoolModifications[mod].icon.baseGlyph;
+
+				const newIOperator = document.createElement('i');
+				newIOperator.className = `fas ${GenesysPoolModifications[mod].icon.operator}`;
+
+				container.appendChild(newIDie);
+				container.appendChild(newIOperator);
+			}
+
+			return container;
+		},
+	});
 }

--- a/src/enrichers.ts
+++ b/src/enrichers.ts
@@ -165,7 +165,7 @@ export function register() {
 	CONFIG.TextEditor.enrichers.push({
 		pattern: new RegExp(`@pool(-mod(ifications?)?)?\\[(?<mods>${PoolModGlyphPattern.source}+)]`, 'gim'),
 		enricher: async (match, _) => {
-			const mods: string[] = match.groups?.['mods']?.match(PoolModGlyphPattern)?.sort((left, right) => GenesysPoolModifications[left].sort - GenesysPoolModifications[right].sort) ?? [];
+			const mods: string[] = match.groups?.['mods']?.match(PoolModGlyphPattern) ?? [];
 
 			const container = document.createElement('span');
 			container.className = 'font-genesys-symbols pool-modifications';

--- a/src/fonts/scss/genesys.scss
+++ b/src/fonts/scss/genesys.scss
@@ -33,6 +33,24 @@
 	&.nolig {
 		font-variant-ligatures: none;
 	}
+
+	&.pool-modifications {
+		.die,
+		.symbol {
+			& + i.fas {
+				-webkit-text-stroke: 0 transparent;
+				text-stroke: 0 transparent;
+				color: black;
+				position: relative;
+				font-size: 0.5em;
+				top: -1em;
+			}
+		}
+
+		.symbol {
+			font-style: normal;
+		}
+	}
 }
 
 .die {
@@ -42,29 +60,35 @@
 	font-family: 'Genesys Symbols', sans-serif;
 
 	// Ability & Difficulty Die
-	&.die-A {
+	&.die-A,
+	&.die-Ability {
 		color: colors.$die-ability;
 	}
 
-	&.die-D {
+	&.die-D,
+	&.die-Difficulty {
 		color: colors.$die-difficulty;
 	}
 
 	// Proficiency Die
-	&.die-P {
+	&.die-P,
+	&.die-Proficiency {
 		color: colors.$die-proficiency;
 	}
 
-	&.die-C {
+	&.die-C,
+	&.die-Challenge {
 		color: colors.$die-challenge;
 	}
 
 	// Boost Die
-	&.die-B {
+	&.die-B,
+	&.die-Boost {
 		color: colors.$die-boost;
 	}
 
-	&.die-S {
+	&.die-S,
+	&.die-Setback {
 		color: colors.$die-setback;
 	}
 }

--- a/src/settings/campaign.ts
+++ b/src/settings/campaign.ts
@@ -7,7 +7,7 @@
  */
 
 import { DEFAULT_DIFFICULTY, DEFAULT_SKILLS_COMPENDIUM, GENESYS_CONFIG } from '@/config';
-import GenesysEffect from '@/effects/GenesysEffect';
+import { PoolModGlyphPattern } from '@/dice/types/GenesysPoolModifications';
 import SkillDataModel from '@/item/data/SkillDataModel';
 import GenesysItem from '@/item/GenesysItem';
 
@@ -105,7 +105,7 @@ export function register(namespace: string) {
 		type: String,
 		onChange: (value) => {
 			const difficulty = value ?? '';
-			const difficultyPattern = new RegExp(`^${GenesysEffect.DICE_POOL_MOD_SKILL_PATTERN.source}*$`);
+			const difficultyPattern = new RegExp(`^${PoolModGlyphPattern.source}*$`);
 			CONFIG.genesys.settings.defaultDifficulty = difficultyPattern.test(difficulty) ? difficulty : DEFAULT_DIFFICULTY;
 		},
 	});


### PR DESCRIPTION
This PR enhance some of the existing enrichers and adds a couple new ones:
- The `@symbol` enricher is stricter now and will only match specific characters. Namely all the ones used for dice symbols plus the ones used for power levels.
- The `@skill-check` enricher can now be called only using `@check`.
  - You can skip specifying the difficulty "rank" and it'll assume it's Average (2) difficulty.
  - If you specify a "rank" you can also specify a number of upgrades to apply to the difficulty by following the "rank" with the `^` symbols and the number of upgrades to apply.
  - The difficulty name now respects locale.
  - Added an alternative format of specifying the check to make it into an opposed check; Follow the name of the first skill by the `|` symbol and then the name of the second skill.
- Added a `@pool-modifications` (shorter versions: `@pool-modification`, `@pool-mod`, `@pool`) enricher to display pool modification symbols. The string you need to set follow the same one used everywhere (see [Dice Pool Modification Glyphs](https://github.com/Mezryss/FVTT-Genesys/wiki/Dice-Pool-Modification-Glyphs)).