### PR TITLE
More options to modify dice pool with effects

### DIFF
--- a/public/templates/sheets/effect-config.hbs
+++ b/public/templates/sheets/effect-config.hbs
@@ -102,9 +102,9 @@
 		<div class="tab" data-group="primary" data-tab="effects">
 			<section class="effect-grid">
 				<div class="header">
-					<div>{{localize 'EFFECT.ChangeKey'}}</div>
-					<div>{{localize 'EFFECT.ChangeMode'}}</div>
-					<div>{{localize 'EFFECT.ChangeValue'}}</div>
+					<div>{{localize 'Genesys.ActiveEffects.ChangeKey'}}</div>
+					<div>{{localize 'Genesys.ActiveEffects.ChangeMode'}}</div>
+					<div>{{localize 'Genesys.ActiveEffects.ChangeValue'}}</div>
 					<div>
 						<a class="effect-control" data-action="add">
 							<i class="far fa-plus-square"></i>
@@ -118,58 +118,72 @@
 							<select name="changes.{{i}}.key">
 								<option value="">—</option>
 
-                                {{!-- Characteristics Changes --}}
-                                <optgroup label="{{localize 'Genesys.ActiveEffects.Types.ModifyCharacteristic'}}">
-                                    {{!-- Character & Adversary Characteristics --}}
-                                    <option value="system.characteristics.brawn">&#x1F9D1; {{localize 'Genesys.Characteristics.Brawn'}}</option>
-                                    <option value="system.characteristics.agility">&#x1F9D1; {{localize 'Genesys.Characteristics.Agility'}}</option>
-                                    <option value="system.characteristics.intellect">&#x1F9D1; {{localize 'Genesys.Characteristics.Intellect'}}</option>
-                                    <option value="system.characteristics.cunning">&#x1F9D1; {{localize 'Genesys.Characteristics.Cunning'}}</option>
-                                    <option value="system.characteristics.willpower">&#x1F9D1; {{localize 'Genesys.Characteristics.Willpower'}}</option>
-                                    <option value="system.characteristics.presence">&#x1F9D1; {{localize 'Genesys.Characteristics.Presence'}}</option>
+                           {{!-- Characteristics Changes --}}
+                           <optgroup label="{{localize 'Genesys.ActiveEffects.Types.ModifyCharacteristic'}}">
+                              {{!-- Character & Adversary Characteristics --}}
+                              <option value="system.characteristics.brawn">&#x1F9D1; {{localize 'Genesys.Characteristics.Brawn'}}</option>
+                              <option value="system.characteristics.agility">&#x1F9D1; {{localize 'Genesys.Characteristics.Agility'}}</option>
+                              <option value="system.characteristics.intellect">&#x1F9D1; {{localize 'Genesys.Characteristics.Intellect'}}</option>
+                              <option value="system.characteristics.cunning">&#x1F9D1; {{localize 'Genesys.Characteristics.Cunning'}}</option>
+                              <option value="system.characteristics.willpower">&#x1F9D1; {{localize 'Genesys.Characteristics.Willpower'}}</option>
+                              <option value="system.characteristics.presence">&#x1F9D1; {{localize 'Genesys.Characteristics.Presence'}}</option>
 
-                                    {{!-- Vehicle Characteristics --}}
-                                    <option value="system.silhouette">&#x1F697; {{localize 'Genesys.Labels.Silhouette'}}</option>
-                                    <option value="system.speed">&#x1F697; {{localize 'Genesys.Labels.Speed'}}</option>
-                                    <option value="system.handling">&#x1F697; {{localize 'Genesys.Labels.Handling'}}</option>
-                                    <option value="system.defense">&#x1F697; {{localize 'Genesys.Labels.Defense'}}</option>
-                                    <option value="system.armor">&#x1F697; {{localize 'Genesys.Labels.Armor'}}</option>
-                                </optgroup>
+                              {{!-- Vehicle Characteristics --}}
+                              <option value="system.silhouette">&#x1F697; {{localize 'Genesys.Labels.Silhouette'}}</option>
+                              <option value="system.speed">&#x1F697; {{localize 'Genesys.Labels.Speed'}}</option>
+                              <option value="system.handling">&#x1F697; {{localize 'Genesys.Labels.Handling'}}</option>
+                              <option value="system.defense">&#x1F697; {{localize 'Genesys.Labels.Defense'}}</option>
+                              <option value="system.armor">&#x1F697; {{localize 'Genesys.Labels.Armor'}}</option>
+                           </optgroup>
 
-                                {{!-- Stat Changes --}}
-                                <optgroup label="{{localize 'Genesys.ActiveEffects.Types.ModifyStat'}}">
-                                    {{!-- Characert and Adversary Secondary Stats --}}
-                                    <option value="system.soak">&#x1F9D1; {{localize 'Genesys.Labels.SoakValue'}}</option>
-                                    <option value="system.wounds.max">&#x1F9D1; {{localize 'Genesys.Labels.WoundThreshold'}}</option>
-                                    <option value="system.strain.max">&#x1F9D1; {{localize 'Genesys.Labels.StrainThreshold'}}</option>
-                                    <option value="system.defense.melee">&#x1F9D1; {{localize 'Genesys.Labels.MeleeDefense'}}</option>
-                                    <option value="system.defense.ranged">&#x1F9D1; {{localize 'Genesys.Labels.RangedDefense'}}</option>
+                           {{!-- Stat Changes --}}
+                           <optgroup label="{{localize 'Genesys.ActiveEffects.Types.ModifyStat'}}">
+                              {{!-- Characert and Adversary Secondary Stats --}}
+                              <option value="system.soak">&#x1F9D1; {{localize 'Genesys.Labels.SoakValue'}}</option>
+                              <option value="system.wounds.max">&#x1F9D1; {{localize 'Genesys.Labels.WoundThreshold'}}</option>
+                              <option value="system.strain.max">&#x1F9D1; {{localize 'Genesys.Labels.StrainThreshold'}}</option>
+                              <option value="system.defense.melee">&#x1F9D1; {{localize 'Genesys.Labels.MeleeDefense'}}</option>
+                              <option value="system.defense.ranged">&#x1F9D1; {{localize 'Genesys.Labels.RangedDefense'}}</option>
 
-                                    {{!-- Vehicle Secondary Stats --}}
-                                    <option value="system.hullTrauma.max">&#x1F697; {{localize 'Genesys.Labels.HullTraumaThreshold'}}</option>
-                                    <option value="system.systemStrain.max">&#x1F697; {{localize 'Genesys.Labels.SystemStrainThreshold'}}</option>
-                                    <option value="system.passengers.value">&#x1F697; {{localize 'Genesys.Labels.Passengers'}}</option>
-                                    <option value="system.passengers.threshold">&#x1F697; {{localize 'Genesys.Labels.PassengerCapacity'}}</option>
+                              {{!-- Vehicle Secondary Stats --}}
+                              <option value="system.hullTrauma.max">&#x1F697; {{localize 'Genesys.Labels.HullTraumaThreshold'}}</option>
+                              <option value="system.systemStrain.max">&#x1F697; {{localize 'Genesys.Labels.SystemStrainThreshold'}}</option>
+                              <option value="system.passengers.value">&#x1F697; {{localize 'Genesys.Labels.Passengers'}}</option>
+                              <option value="system.passengers.threshold">&#x1F697; {{localize 'Genesys.Labels.PassengerCapacity'}}</option>
 
-                                    {{!-- Shared Secondary Stats --}}
-                                    <option value="system.encumbrance.value">&#x1F310; {{localize 'Genesys.Labels.Encumbrance'}}</option>
-                                    <option value="system.encumbrance.threshold">&#x1F310; {{localize 'Genesys.Labels.EncumbranceThreshold'}}</option>
-                                </optgroup>
+                              {{!-- Shared Secondary Stats --}}
+                              <option value="system.encumbrance.value">&#x1F310; {{localize 'Genesys.Labels.Encumbrance'}}</option>
+                              <option value="system.encumbrance.threshold">&#x1F310; {{localize 'Genesys.Labels.EncumbranceThreshold'}}</option>
+                           </optgroup>
 
-								{{!-- Skill Changes --}}
+                           {{!-- Skill Changes --}}
 
-								{{!-- Dice Pool Changes --}}
-                                <optgroup label="{{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.GroupLabel'}}">
-                                    <option value="genesys.pool.skill">&#x1F9D1; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Skill'}}</option>
-                                </optgroup>
+                           {{!-- Dice Pool Changes --}}
+                           <optgroup label="{{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.GroupLabel'}}">
+                              {{!-- Modifications from the Roller --}}
+                              <option value="genesys.pool.check.self">&#x1F481; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Check'}}</option>
+                              <option value="genesys.pool.char.self">&#x1F481; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Characteristic'}}</option>
+                              <option value="genesys.pool.skill.self">&#x1F481; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Skill'}}</option>
+
+                              {{!-- Modifications from the Target --}}
+                              <option value="genesys.pool.check.target">&#x1F64B; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Check'}}</option>
+                              <option value="genesys.pool.char.target">&#x1F64B; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Characteristic'}}</option>
+                              <option value="genesys.pool.skill.target">&#x1F64B; {{localize 'Genesys.ActiveEffects.Types.ModifyDicePool.Options.Skill'}}</option>
+                           </optgroup>
 							</select>
 						{{/select}}
-                        <select name="changes.{{i}}.skill" class="skill-selection {{#if (ne change.key 'genesys.pool.skill')}}hide-it{{/if}}">
-                            {{selectOptions ../skills selected=change.skill sort=true}}
-                        </select>
-                        <select name="changes.{{i}}.mode" data-dtype="Number" class="effect-mode {{#if (eq change.key 'genesys.pool.skill')}}hide-it{{/if}}">
-                            {{selectOptions ../modes selected=change.mode}}
-                        </select>
+                  <div>
+                     <div class="check-selection initial-hide {{#if (isSubstringOf 'genesys.pool.check.' change.key)}}show-it{{/if}}">—</div>
+                     <select name="changes.{{i}}.char" class="characteristic-selection initial-hide {{#if (isSubstringOf 'genesys.pool.char.' change.key)}}show-it{{/if}}">
+                           {{selectOptions ../characteristics selected=change.char sort=true}}
+                     </select>
+                     <select name="changes.{{i}}.skill" class="skill-selection initial-hide {{#if (isSubstringOf 'genesys.pool.skill.' change.key)}}show-it{{/if}}">
+                           {{selectOptions ../skills selected=change.skill sort=true}}
+                     </select>
+                     <select name="changes.{{i}}.mode" data-dtype="Number" class="effect-mode initial-hide {{#if (not (isSubstringOf 'genesys.pool.' change.key))}}show-it{{/if}}">
+                           {{selectOptions ../modes selected=change.mode}}
+                     </select>
+                  </div>
 						<input type="text" name="changes.{{i}}.value" value="{{change.value}}" />
 						<div class="effect-controls">
 							<a class="effect-control" data-action="delete"><i class="fas fa-trash"></i></a>

--- a/src/effects/GenesysEffect.ts
+++ b/src/effects/GenesysEffect.ts
@@ -14,9 +14,20 @@ export default class GenesysEffect extends ActiveEffect {
 		return this.disabled;
 	}
 
-	// Prefix string used to identify active effects that are supposed to modify a dice pool that is using a specific
-	// skill.
-	static DICE_POOL_MOD_SKILL_PREFIX = 'genesys.pool.skill';
+	// Prefix string used to identify active effects that are supposed to modify a dice pool.
+	static DICE_POOL_MOD_KEY_PREFIX = 'genesys.pool.';
+
+	// Indetifiers for the different types of rolls for which we can modify the dice pool.
+	static DICE_POOL_MOD_CHECK_TYPE = 'check.';
+	static DICE_POOL_MOD_CHAR_TYPE = 'char.';
+	static DICE_POOL_MOD_SKILL_TYPE = 'skill.';
+
+	// Identifiers for the source of the active effects affecting a dice pool.
+	static DICE_POOL_MOD_SELF_SOURCE = 'self';
+	static DICE_POOL_MOD_TARGET_SOURCE = 'target';
+
+	// Unified pattern to identify an active effect key that modifies the dice pool.
+	static DICE_POOL_MOD_KEY_PATTERN = /(?<=genesys\.pool\.(?:check|char|skill)\.(?:self|target))\.?/;
 
 	get originItem(): GenesysItem | undefined {
 		if (!this.origin || !(this.parent instanceof GenesysActor) || !this.origin.includes('.Item.')) {

--- a/src/effects/GenesysEffectSheet.scss
+++ b/src/effects/GenesysEffectSheet.scss
@@ -138,8 +138,16 @@
 			grid-template-columns: /* Key */ 2fr /* Change Mode */ 1fr /* Value */ 1fr /* Actions */ auto;
 		}
 
-		.hide-it {
+		.check-selection {
+			text-align: center;
+		}
+
+		.initial-hide {
 			display: none;
+		}
+
+		.show-it {
+			display: inherit;
 		}
 	}
 }

--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -8,30 +8,31 @@
 
 export function register() {
 	/** String Utilities */
-	Handlebars.registerHelper('capitalize', /** @param {string} value */ (value) => value.capitalize());
-	Handlebars.registerHelper('toLowerCase', /** @param {string} value */ (value) => value.toLowerCase());
-	Handlebars.registerHelper('toUpperCase', /** @param {string} value */ (value) => value.toUpperCase());
-	Handlebars.registerHelper('concat', (...values) => values.filter((v) => v && typeof v === 'string').join(''));
-	Handlebars.registerHelper('split', /** @param {string} value */ (value) => value.split(' '));
+	Handlebars.registerHelper('capitalize', (value: string) => value.capitalize());
+	Handlebars.registerHelper('toLowerCase', (value: string) => value.toLowerCase());
+	Handlebars.registerHelper('toUpperCase', (value: string) => value.toUpperCase());
+	Handlebars.registerHelper('concat', (...values: any[]) => values.filter((v) => v && typeof v === 'string').join(''));
+	Handlebars.registerHelper('split', (value: string) => value.split(' '));
+	Handlebars.registerHelper('isSubstringOf', (substring: string, fullString: string) => fullString.includes(substring));
 
 	/** Math Utilities */
-	Handlebars.registerHelper('add', (lhs, rhs) => lhs + rhs);
-	Handlebars.registerHelper('sub', (lhs, rhs) => lhs - rhs);
-	Handlebars.registerHelper('mul', (lhs, rhs) => lhs * rhs);
-	Handlebars.registerHelper('div', (lhs, rhs) => lhs / rhs);
-	Handlebars.registerHelper('min', (lhs, rhs) => Math.min(lhs, rhs));
-	Handlebars.registerHelper('max', (lhs, rhs) => Math.max(lhs, rhs));
-	Handlebars.registerHelper('abs', (val) => Math.abs(val));
-	Handlebars.registerHelper('floor', (val) => Math.floor(val));
+	Handlebars.registerHelper('add', (lhs: number, rhs: number) => lhs + rhs);
+	Handlebars.registerHelper('sub', (lhs: number, rhs: number) => lhs - rhs);
+	Handlebars.registerHelper('mul', (lhs: number, rhs: number) => lhs * rhs);
+	Handlebars.registerHelper('div', (lhs: number, rhs: number) => lhs / rhs);
+	Handlebars.registerHelper('min', (lhs: number, rhs: number) => Math.min(lhs, rhs));
+	Handlebars.registerHelper('max', (lhs: number, rhs: number) => Math.max(lhs, rhs));
+	Handlebars.registerHelper('abs', (val: number) => Math.abs(val));
+	Handlebars.registerHelper('floor', (val: number) => Math.floor(val));
 	Handlebars.registerHelper('toFixed', (val: number, fractionDigits: number) => val.toFixed(fractionDigits));
 
 	/** Logic Utilities */
-	Handlebars.registerHelper('and', (lhs, rhs) => lhs && rhs);
-	Handlebars.registerHelper('or', (lhs, rhs) => lhs || rhs);
-	Handlebars.registerHelper('not', (val) => !val);
+	Handlebars.registerHelper('and', (lhs: boolean, rhs: boolean) => lhs && rhs);
+	Handlebars.registerHelper('or', (lhs: boolean, rhs: boolean) => lhs || rhs);
+	Handlebars.registerHelper('not', (val: boolean) => !val);
 
 	/** Iteration utilities */
-	Handlebars.registerHelper('repeat', (times, options) => {
+	Handlebars.registerHelper('repeat', (times: number, options: { fn: (time: number) => string | number }) => {
 		const results = [];
 
 		for (let i = 0; i < times; i++) {

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -148,6 +148,9 @@ Genesys:
     Suppressed: Inactive Effects
     Source: Source
     Duration: Duration
+    ChangeKey: Effect Target
+    ChangeMode: Option
+    ChangeValue: Effect Value
     Types:
       ModifyCharacteristic: Modify Characteristic
       ModifyStat: Modify Stat
@@ -155,7 +158,9 @@ Genesys:
       ModifyDicePool:
         GroupLabel: Modify Dice Pool
         Options:
-          Skill: Skill Dice Pool
+          Check: Any Check
+          Characteristic: Uses Characteristic
+          Skill: Uses Skill
 
   # Dice Prompt Labels
   DicePrompt:
@@ -167,6 +172,8 @@ Genesys:
       Title: Pool Modifications
       DefaultDifficulty: Default Difficulty
       ManualChanges: Manual Changes
+      SelfEffects: 'From Self: '
+      TargetEffects: 'From Target: '
     ChanceToSucceed: 'Chance to Succeed:'
     ChanceToSucceedByPermutationDisclaimer: The displayed probability is exact unless the dice pool includes a super-characteristic.
     ChanceToSucceedBySimulationDisclaimer: The displayed probability is an approximation that uses the Monte Carlo method.

--- a/yaml/lang/es.yml
+++ b/yaml/lang/es.yml
@@ -148,6 +148,9 @@ Genesys:
     Suppressed: Efectos inactivos
     Source: Origen
     Duration: Duración
+    ChangeKey: Objetivo del efecto
+    ChangeMode: Opción
+    ChangeValue: Valor del efecto
     Types:
       ModifyCharacteristic: Característica modificada
       ModifyStat: Estadística modificada
@@ -155,7 +158,9 @@ Genesys:
       ModifyDicePool:
         GroupLabel: Modificar reserva de dados
         Options:
-          Skill: Habilidad de la reserva de dados
+          Check: Cualquier tirada
+          Characteristic: Utiliza característica
+          Skill: Utiliza habilidad
 
   # Dice Prompt Labels
   DicePrompt:
@@ -167,6 +172,8 @@ Genesys:
       Title: Modificaciones de la reserva
       DefaultDifficulty: Dificultad por defecto
       ManualChanges: Cambios manuales
+      SelfEffects: 'Propios: '
+      TargetEffects: 'Objetivo: '
     ChanceToSucceed: 'Posibilidades de éxito:'
     ChanceToSucceedByPermutationDisclaimer: La probabilidad mostrada es exacta a menos que la reserva de dados incluya una supercaracterística.
     ChanceToSucceedBySimulationDisclaimer: La probabilidad mostrada es una aproximación que utiliza el método Monte Carlo.

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -148,6 +148,9 @@ Genesys:
     Suppressed: Effets Désactivés
     Source: Source
     Duration: Durée
+    ChangeKey: Effect Target
+    ChangeMode: Option
+    ChangeValue: Effect Value
     Types:
       ModifyCharacteristic: Caractérisitique à Modifier
       ModifyStat: Statistique à Modifier
@@ -155,7 +158,9 @@ Genesys:
       ModifyDicePool:
         GroupLabel: Réserve de Dés à Modifier
         Options:
-          Skill: Skill Dice Pool
+          Check: Any Check
+          Characteristic: Uses Characteristic
+          Skill: Uses Skill
 
   # Dice Prompt Labels
   DicePrompt:
@@ -167,6 +172,8 @@ Genesys:
       Title: Pool Modifications
       DefaultDifficulty: Default Difficulty
       ManualChanges: Manual Changes
+      SelfEffects: 'From Self: '
+      TargetEffects: 'From Target: '
     ChanceToSucceed: 'Chance de réussite:'
     ChanceToSucceedByPermutationDisclaimer: "Affiche la probabilité exacte à moins qu'un dé dans le pool soit une super-caractéristique."
     ChanceToSucceedBySimulationDisclaimer: La probabilité affiché est une approximation caculé à partir de la méthode de Monte Carlo.


### PR DESCRIPTION
- Add more ways of modifying a character or adversary dice pool using active effects:
  - As before you can pick a specific skill to gain the benefit
  - You can now also pick any roll that uses a specific characteristic
  - You can also choose to always apply a modification regardless of the roll
- Adds way to modify the dice pool of a character or adversary if they target another character or adversary with a modification
  - This allows for the same three modifications mentioned on the previous point
- On the dropdown this options will show two different emoticons. For modifications to the dice pool coming from the roller the emoticon used is 💁 (person tipping hand). For modification to the dice pool when targeted the emoticon used is 🙋 (person raising hand).
- Also if targeting a character with an attack, a toggleable modification will show up that adds a number of setback dice to the pool equal to the target's defense. If the weapon used for the attack has a range of engaged it will use the melee defense to determine this number, otherwise it uses the ranged defense.

_**Note: The modifications to the dice pool when targeting works exclusively with ONE target character.**_

![image](https://github.com/user-attachments/assets/8a4a4f5a-7330-40f8-bdac-ecb67bad574d)
![image](https://github.com/user-attachments/assets/16a51533-746f-4116-bd21-83bf92ada806)
![image](https://github.com/user-attachments/assets/50e9f33b-6b31-44e9-a434-b1ceddf56184)
![image](https://github.com/user-attachments/assets/b14232f2-f453-4581-9b00-623f6c957bd7)