### PR TITLE
Fix Skills tab on vehicles for minions

### DIFF
--- a/src/actor/data/VehicleDataModel.ts
+++ b/src/actor/data/VehicleDataModel.ts
@@ -451,7 +451,7 @@ export function register() {
 			VehicleDataModel._GAME_VEHICLES.delete(targetActor as GenesysActor<VehicleDataModel>);
 		} else {
 			// Whenever a non-vehicle actor is deleted let the primary GM remove it from all the vehicles in the world.
-			const isGmHub = game.users.activeGM?.isSelf ?? (game.user.isGM && game.users.filter((user) => user.isGM && user.active).every((candidate) => candidate.id >= game.user.id));
+			const isGmHub = game.users.activeGM?.isSelf;
 			if (isGmHub) {
 				const genesysActorUuid = targetActor.uuid;
 				for (const vehicle of VehicleDataModel._GAME_VEHICLES) {

--- a/src/vue/sheets/actor/vehicle/SkillsTab.vue
+++ b/src/vue/sheets/actor/vehicle/SkillsTab.vue
@@ -7,6 +7,7 @@ import GenesysItem from '@/item/GenesysItem';
 import SkillDataModel from '@/item/data/SkillDataModel';
 import CharacterDataModel from '@/actor/data/CharacterDataModel';
 import AdversaryDataModel from '@/actor/data/AdversaryDataModel';
+import MinionDataModel from '@/actor/data/MinionDataModel';
 
 import DicePrompt from '@/app/DicePrompt';
 import Localized from '@/vue/components/Localized.vue';
@@ -42,7 +43,7 @@ const groupedByMember = ref<Map<string, GroupedByMemberData>>(new Map());
 const groupedBySkill = ref<Map<string, GroupedBySkillData>>(new Map());
 
 watch(
-	[context.sheet, groupingMode],
+	[toRaw(context.data), groupingMode],
 	async () => {
 		const actorData = toRaw(context.data.actor).systemData;
 		const allActorSkills = new Map<string, GroupedByMemberData>();
@@ -172,7 +173,10 @@ async function openActorSheet(actor: GenesysActor) {
 								</a>
 
 								<span class="skill-rank">{{ skill.systemData.rank }}</span>
-								<SkillRanks :skill-value="skill.systemData.rank" :characteristic-value="(details.actor.systemData as NonVehicleDataModel).characteristics[skill.systemData.characteristic]" />
+								<SkillRanks
+									:skill-value="details.actor.type === 'minion' ? Math.max(0, (details.actor.systemData as MinionDataModel).remainingMembers - 1) : skill.systemData.rank"
+									:characteristic-value="(details.actor.systemData as NonVehicleDataModel).characteristics[skill.systemData.characteristic]"
+								/>
 							</div>
 						</div>
 					</div>
@@ -200,7 +204,7 @@ async function openActorSheet(actor: GenesysActor) {
 							<div class="skill-content-details-skillRank">{{ actorRoleSkill.skill.systemData.rank }}</div>
 							<a @click="rollSkillForActor(actorRoleSkill.actor as GenesysActor<NonVehicleDataModel>, actorRoleSkill.skill as GenesysItem<SkillDataModel>)">
 								<SkillRanks
-									:skill-value="actorRoleSkill.skill.systemData.rank"
+									:skill-value="actorRoleSkill.actor.type === 'minion' ? Math.max(0, (actorRoleSkill.actor.systemData as MinionDataModel).remainingMembers - 1) : actorRoleSkill.skill.systemData.rank"
 									:characteristic-value="(actorRoleSkill.actor.systemData as NonVehicleDataModel).characteristics[actorRoleSkill.skill.systemData.characteristic]"
 								/>
 							</a>


### PR DESCRIPTION
- The vehicle's Skills Tab now properly calculates the ranks for minions
- Fixed a bug that was preventing the Vehicle sheet from open under certain circumstances