### PR TITLE
Fix `@check` enricher to properly set the difficulty when clicked

### DIFF
--- a/src/actor/GenesysActorSheet.ts
+++ b/src/actor/GenesysActorSheet.ts
@@ -35,12 +35,13 @@ export default class GenesysActorSheet<ActorDataModel extends foundry.abstract.D
 		}
 
 		setTimeout(() => {
+         html.find('[data-skill-check]').off('click');
 			html.find('[data-skill-check]').on('click', async (event) => {
 				const target = $(event.delegateTarget);
 
 				// Grab the skill name & difficulty
 				const skillName: string = target.data('skill-check');
-				const difficulty: string = 'D'.repeat(parseInt(target.data('difficulty')));
+				const difficulty: string = target.data('difficulty');
 
 				await DicePrompt.promptForRoll(this.actor, skillName, { difficulty });
 			});

--- a/src/actor/GenesysActorSheet.ts
+++ b/src/actor/GenesysActorSheet.ts
@@ -35,7 +35,7 @@ export default class GenesysActorSheet<ActorDataModel extends foundry.abstract.D
 		}
 
 		setTimeout(() => {
-         html.find('[data-skill-check]').off('click');
+			html.find('[data-skill-check]').off('click');
 			html.find('[data-skill-check]').on('click', async (event) => {
 				const target = $(event.delegateTarget);
 


### PR DESCRIPTION
The `onClick` listener attached to the links generated by using the `@check` text enricher were not migrated to the new way of specifying the difficulty. This PR should fix that.