### PR TITLE
Fix minion skills going over rank 5

### DIFF
--- a/src/combat/GenesysCombatant.ts
+++ b/src/combat/GenesysCombatant.ts
@@ -51,7 +51,7 @@ export default class GenesysCombatant extends Combatant<GenesysCombat, GenesysAc
 
 		let skillValue = skill?.systemData?.rank ?? 0;
 		if (skill && this.actor.type === 'minion') {
-			skillValue = Math.max(0, (this.actor.systemData as MinionDataModel).remainingMembers - 1);
+			skillValue = Math.min(Math.max(0, (this.actor.systemData as MinionDataModel).remainingMembers - 1), 5);
 		}
 
 		const yellow = Math.min(characteristicValue, skillValue);

--- a/src/vue/apps/DicePrompt.vue
+++ b/src/vue/apps/DicePrompt.vue
@@ -249,7 +249,7 @@ function buildDicePool() {
 		let skillValue = selectedSkill.value?.systemData.rank ?? 0;
 
 		if (actor.type === 'minion' && selectedSkill.value) {
-			skillValue = Math.max(0, (actor.systemData as MinionDataModel).remainingMembers - 1);
+			skillValue = Math.min(Math.max(0, (actor.systemData as MinionDataModel).remainingMembers - 1), 5);
 		}
 
 		proficiencyDice = Math.min(characteristicValue, skillValue);

--- a/src/vue/sheets/actor/MinionSheet.vue
+++ b/src/vue/sheets/actor/MinionSheet.vue
@@ -100,7 +100,7 @@ async function deleteItem(item: GenesysItem) {
 
 					<a @click="rollSkill(skill)">
 						<span>{{ skill.name }}</span>
-						<SkillRanks :skill-value="Math.max(0, system.remainingMembers - 1)" :characteristic-value="system.characteristics[skill.systemData.characteristic]" />
+						<SkillRanks :skill-value="Math.min(Math.max(0, system.remainingMembers - 1), 5)" :characteristic-value="system.characteristics[skill.systemData.characteristic]" />
 					</a>
 				</ContextMenu>
 			</div>


### PR DESCRIPTION
Minions that had more than 6 members were showing skills with more than 5 ranks. This PR now caps the skills to 5.