### PR TITLE
Allows to add a career so long no skills have been ranked up

### DIFF
--- a/src/actor/sheets/CharacterSheet.ts
+++ b/src/actor/sheets/CharacterSheet.ts
@@ -93,7 +93,7 @@ export default class CharacterSheet extends VueSheet(GenesysActorSheet<Character
 			} else if (droppedItem.type === 'career') {
 				// If it's a career, delete the old one and apply the new one.
 
-				if (this.actor.systemData.experienceJournal.entries.length > 1) {
+				if (this.actor.systemData.experienceJournal.entries.some((entry) => entry.type === EntryType.Skill)) {
 					return false;
 				}
 


### PR DESCRIPTION
Fixes #157

Note: We still restrict when a career can be applied/exchanged but now the condition is more relaxed. Previously the moment you spent XP it locked you out of adding a career. Now, so long no XP is used on skills it will let you add a career.