### PR TITLE
Prevent an invalid talent pyramid due to a journal entry removal

### DIFF
--- a/src/actor/data/character/ExperienceJournal.ts
+++ b/src/actor/data/character/ExperienceJournal.ts
@@ -103,8 +103,6 @@ type TalentRankEntryData = {
 
 export async function removeJournalEntry(actor: GenesysActor<CharacterDataModel>, index: number) {
 	if (index >= actor.systemData.experienceJournal.entries.length) {
-		console.warn(`Attempted to remove XP journal entry with index ${index}, but this index is out of bounds!`);
-		console.warn(actor.systemData.experienceJournal.entries);
 		return;
 	}
 
@@ -173,8 +171,16 @@ export async function removeJournalEntry(actor: GenesysActor<CharacterDataModel>
 				break;
 			}
 
-			if (data.rank !== talent.system.rank) {
+			if (data.rank !== talent.systemData.rank) {
 				ui.notifications.info(game.i18n.format('Genesys.Notifications.CannotDeleteExistingTalent', data));
+				return;
+			}
+
+			const talentPyramidTotals = actor.systemData.talentPyramidTotals;
+			const talentEffectiveTier = talent.systemData.effectiveTier;
+			const totalNextTier = talentPyramidTotals[talentEffectiveTier + 1];
+			if (talentEffectiveTier < 5 && totalNextTier > 0 && totalNextTier >= talentPyramidTotals[talentEffectiveTier] - 1) {
+				ui.notifications.info(game.i18n.format('Genesys.Notifications.CannotDeleteInvalidTalentPyramid', { rank: talentEffectiveTier }));
 				return;
 			}
 
@@ -191,8 +197,16 @@ export async function removeJournalEntry(actor: GenesysActor<CharacterDataModel>
 				break;
 			}
 
-			if (data.rank !== talent.system.rank) {
+			if (data.rank !== talent.systemData.rank) {
 				ui.notifications.info(game.i18n.format('Genesys.Notifications.CannotDeleteExistingTalent', data));
+				return;
+			}
+
+			const talentPyramidTotals = actor.systemData.talentPyramidTotals;
+			const talentEffectiveTier = talent.systemData.effectiveTier;
+			const totalNextTier = talentPyramidTotals[talentEffectiveTier + 1];
+			if (talentEffectiveTier < 5 && totalNextTier > 0 && totalNextTier >= talentPyramidTotals[talentEffectiveTier] - 1) {
+				ui.notifications.info(game.i18n.format('Genesys.Notifications.CannotDeleteInvalidTalentPyramid', { rank: talentEffectiveTier }));
 				return;
 			}
 

--- a/yaml/lang/en.yml
+++ b/yaml/lang/en.yml
@@ -226,6 +226,7 @@ Genesys:
     CannotAffordRankedTalent: Cannot afford to increase talent '{name}' to rank {newRank} ({cost}xp).
     CannotDeleteNewTalent: Cannot delete XP Journal Entry for new talent '{name}' - you must delete the talent's rank increases first!
     CannotDeleteExistingTalent: Cannot delete XP Journal Entry for increasing talent '{name}' to rank {rank} - you must delete the higher rank increases first!
+    CannotDeleteInvalidTalentPyramid: Cannot delete XP Journal Entry for talent of rank {rank} to preserve the talent pyramid structure. Try deleting talents of higher rank first.
     CannotPurchaseTalentTier: Cannot purchase talents at tier {tier} - you must have at least {minimum} talents at rank {lowerTier} first.
     NotEnoughStoryPoints: You can't spend Story Points you don't have!
     SelectOneTokenForAction: You need to selected a single token to perform this action.

--- a/yaml/lang/es.yml
+++ b/yaml/lang/es.yml
@@ -226,6 +226,7 @@ Genesys:
     CannotAffordRankedTalent: No puedes permitirte incrementar el talento '{name}' al rango {newRank} ({cost}pe).
     CannotDeleteNewTalent: No puedes eliminar la entrada del diario del nuevo talento '{name}' - ¡primero debes eliminar los aumentos de rango del talento!
     CannotDeleteExistingTalent: No puedes eliminar la entrada del diario de PE del talento mejorado '{name}' al rango {rank} - ¡primero debes eliminar los rangos superiores!
+    CannotDeleteInvalidTalentPyramid: No puedes eliminar la entrada del diario de PE del talento de rango {rank} para preservar la pirámide de talentos. Intenta borrando talentos de rango mas bajo.
     CannotPurchaseTalentTier: No puedes comprar talentos de nivel {tier} - primero debes tener al menos {minimum} talentos de nivel {lowerTier}.
     NotEnoughStoryPoints: ¡No puedes gastar puntos de Historia que no tienes!
     SelectOneTokenForAction: Debes seleccionar un único token para realizar esta acción.

--- a/yaml/lang/fr.yml
+++ b/yaml/lang/fr.yml
@@ -225,6 +225,7 @@ Genesys:
     CannotAffordRankedTalent: "Impossible d'augmenter le talent '{name}' au rang {newRank} ({cost}xp)."
     CannotDeleteNewTalent: Impossible de supprimer l'entrée du journal d'XP pour le nouveau talent '{name}' - Vous devez d'abord supprimer les augmentations de rang du talent !
     CannotDeleteExistingTalent: "Impossible de supprimer l'entrée du journal de XP pour l'augmentation du talent '{name}' au rang {rank} - Vous devez d'abord supprimer les augmentations de rang supérieur !"
+    CannotDeleteInvalidTalentPyramid: Cannot delete XP Journal Entry for talent of rank {rank} to preserve the talent pyramid structure. Try deleting talents of higher rank first.
     CannotPurchaseTalentTier: "Vous ne pouvez prendre des talents de la catégorie {tier} - vous devez avoir au moins {minimum} talents à la catégorie {lowerTier} d'abord"
     NotEnoughStoryPoints: Vous ne pouvez pas dépenser de Point Narratif que vous ne possédez pas!
     SelectOneTokenForAction: Vous devez selectionner un unique token pour réaliser cette action.


### PR DESCRIPTION
Currently you can remove the last upgrade of a specific talent and cause the talent pyramid to become invalid. This happens because the total count of talents at a specific tier might fluctuate and make it so that a lower tier doesn't have more talents than a higher tier. This PR prevents that from happening via the Journal tab.