### PR TITLE
Fixes ligatures on Chromium

### DIFF
--- a/src/scss/chat/rolls.scss
+++ b/src/scss/chat/rolls.scss
@@ -109,6 +109,7 @@ $size: 2rem;
 				position: relative;
 				top: -0.25em;
 				font-size: 1.5em;
+				font-variant-ligatures: common-ligatures;
 
 				&[data-type='S'],
 				&[data-type='I'],


### PR DESCRIPTION
Hi, just a small fix for Chromium-based browsers because we all love our icons pretty. :nail_care: 

<img width="252" height="119" alt="image" src="https://github.com/user-attachments/assets/8959b6c8-307c-4f0c-a75a-9bbb008aba9e" />


<img width="252" height="119" alt="image" src="https://github.com/user-attachments/assets/5f71ae99-7eb4-4d96-814a-6c60960ab86a" />

Fixes https://github.com/Mezryss/FVTT-Genesys/issues/220
