### PR TITLE
Adds a chat command to prompt the dice roller

### DIFF
--- a/src/Genesys.ts
+++ b/src/Genesys.ts
@@ -175,6 +175,16 @@ Hooks.on('renderChatLog', (_sidebar: SidebarTab, html: JQuery<HTMLElement>, _dat
 	});
 });
 
+// Allow to open the DicePrompt on chat command /gendr (for GENesys Dice Roller), thus allowing to open it from a macro
+Hooks.on('chatMessage', (chatLog: ChatLog, message: string, _chatData: any) => {
+	const commandR = /^\/gendr(?:oll)?/i;
+	if (message.match(commandR)) {
+		DicePrompt.promptForRoll(undefined, '');
+		return false;
+	}
+	return true;
+});
+
 // Create wiki links in the description section of certain settings. We use a hook here since there is no way to
 // directly add links as any HTML is escaped.
 const wikiLinkPattern = /\[\[([^|\]]+)(\|([^\]]+))?\]\]/g;

--- a/types/foundry/client/core/hooks.d.ts
+++ b/types/foundry/client/core/hooks.d.ts
@@ -21,6 +21,7 @@ declare global {
 	type HooksParamsPreUpdateCombat = HookParameters<'preUpdateCombat', [Combat, object, { diff: boolean; advanceTime: number; [key: string]: unknown }, string]>;
 	type HookParamsPreUpdateToken = HookParameters<'preUpdateToken', [Scene, foundry.data.TokenData, Partial<foundry.data.TokenData>, { diff: boolean; [key: string]: unknown }, string]>;
 	type HookParamsRender<T extends Application, N extends string> = HookParameters<`render${N}`, [T, JQuery, ReturnType<T['getData']>]>;
+	type HookParamsChatMessage = HookParameters<'chatMessage', [ChatLog, string, any]>;
 	type HookParamsRenderChatMessage = HookParameters<'renderChatMessage', [ChatMessage, JQuery, foundry.data.ChatMessageSource]>;
 	type HookParamsTargetToken = HookParameters<'targetToken', [User, Token, boolean]>;
 	type HookParamsUpdate<T extends ClientDocument, N extends string> = HookParameters<`update${N}`, [T, DocumentUpdateData<T>, DocumentModificationContext]>;
@@ -47,6 +48,7 @@ declare global {
 		static on(...args: HookParamsPreCreateItem): number;
 		static on(...args: HooksParamsPreUpdateCombat): number;
 		static on(...args: HookParamsPreUpdateToken): number;
+		static on(...args: HookParamsChatMessage): number;
 		static on(...args: HookParamsRenderChatMessage): number;
 		static on(...args: HookParamsRender<ChatLog, 'ChatLog'>): number;
 		static on(...args: HookParamsRender<ChatPopout, 'ChatPopout'>): number;
@@ -88,6 +90,7 @@ declare global {
 		static once(...args: HookParamsLightingRefresh): number;
 		static once(...args: HookParamsPreCreateItem): number;
 		static once(...args: HookParamsPreUpdateToken): number;
+		static once(...args: HookParamsChatMessage): number;
 		static once(...args: HookParamsRenderChatMessage): number;
 		static once(...args: HookParamsRender<ActorDirectory<Actor>, 'ActorDirectory'>): number;
 		static once(...args: HookParamsRender<ChatLog, 'ChatLog'>): number;


### PR DESCRIPTION
I added a chat command to allow opening the Dice Roller from a macro.
I just plug into the hooks and parse the messages.

I might have some improvements to add ~~before merging~~ (it will be a separate PR) if you want to try it yourself. It's intended as a solution for: https://github.com/Mezryss/FVTT-Genesys/discussions/222 and https://github.com/Mezryss/FVTT-Genesys/discussions/216

https://github.com/user-attachments/assets/c10640c9-acc7-430f-a7b8-cfc2d7127af8

