### PR TITLE
Fix story point values being unreadable in FoundryVTT v13

### DIFF
--- a/src/vue/apps/StoryPointTracker.vue
+++ b/src/vue/apps/StoryPointTracker.vue
@@ -101,6 +101,7 @@ async function toggleEdit(which: 'gm' | 'player') {
 	position: absolute;
 	bottom: 20px;
 	right: 320px;
+	color: var(--color-dark-1);
 
 	&.move-to-left {
 		bottom: 15px;


### PR DESCRIPTION
This PR fixes the story point text color in FoundryVTT v13

<img width="164" height="198" alt="image" src="https://github.com/user-attachments/assets/cc573d6b-4632-4644-ab02-e6c2995c4d12" />

<img width="175" height="206" alt="image" src="https://github.com/user-attachments/assets/5b0aff27-e921-4255-95f3-23b58261a9f7" />
