### PR TITLE
Fix cut off sheet titles

### DIFF
--- a/src/vue/sheets/actor/AdversarySheet.vue
+++ b/src/vue/sheets/actor/AdversarySheet.vue
@@ -673,6 +673,7 @@ onBeforeUpdate(updateEffects);
 			font-family: 'Bebas Neue', sans-serif;
 			font-size: 2rem;
 			color: colors.$blue;
+			height: 2rem;
 
 			&,
 			&:focus {

--- a/src/vue/sheets/actor/VehicleSheet.vue
+++ b/src/vue/sheets/actor/VehicleSheet.vue
@@ -141,6 +141,7 @@ onBeforeUpdate(updateEffects);
 			font-family: 'Bebas Neue', sans-serif;
 			font-size: 2rem;
 			color: colors.$blue;
+			height: 2rem;
 
 			&,
 			&:focus {

--- a/src/vue/sheets/item/BasicItemSheet.vue
+++ b/src/vue/sheets/item/BasicItemSheet.vue
@@ -169,6 +169,7 @@ onBeforeUpdate(updateEffects);
 			font-family: 'Bebas Neue', sans-serif;
 			font-size: 2rem;
 			color: colors.$blue;
+			height: 2rem;
 
 			&,
 			&:focus {


### PR DESCRIPTION
This PR fixes the cut off sheet titles on adversary, vehicle and item sheets.

<img width="189" height="67" alt="image" src="https://github.com/user-attachments/assets/346e22bd-9f08-4cab-8fd0-568db2b35c41" />

<img width="228" height="67" alt="image" src="https://github.com/user-attachments/assets/8f376653-f0e9-4420-96b2-7e2be998955d" />
