### PR TITLE
Fix duplication of active abilities without activation phrase in talents tab

### DIFF
--- a/src/vue/sheets/actor/character/TalentsTab.vue
+++ b/src/vue/sheets/actor/character/TalentsTab.vue
@@ -22,7 +22,7 @@ const activeAbilities = computed(
 				return a.name.localeCompare(b.name);
 			}) as GenesysItem<AbilityDataModel>[],
 );
-const activeAbilityTypes = computed(() => Array.from(new Set(activeAbilities.value.map((t) => t.systemData.activation.detail.toLowerCase()))));
+const activeAbilityTypes = computed(() => Array.from(new Set(activeAbilities.value.map((t) => t.systemData.activation.detail.toLowerCase()))).filter(t => t !== ''));
 const passiveAbilities = computed(
 	() =>
 		toRaw(context.data.actor)
@@ -129,7 +129,7 @@ async function openItem(item: GenesysItem) {
 				/>
 
 				<!-- Active Abilities w/Description -->
-				<template v-for="activeType in activeAbilityTypes.filter(t => t !== '')" :key="activeType">
+				<template v-for="activeType in activeAbilityTypes" :key="activeType">
 					<div class="sub-category-header">{{ activeType }}</div>
 					<Talent
 						v-for="ability in activeAbilities.filter((t) => t.systemData.activation.detail.toLowerCase() === activeType)"


### PR DESCRIPTION
This PR removes the duplication of active abilities without an activation phrase from the character sheets talents tab.