### PR TITLE
Fix simple difficulty showing as empty brackets in skill check enricher

### DIFF
--- a/src/enrichers.ts
+++ b/src/enrichers.ts
@@ -151,7 +151,7 @@ export function register() {
 				'<i class="far fa-dice-d10"></i> ' +
 				game.i18n.format('Genesys.Enrichers.Difficulty', {
 					difficulty: difficultyName,
-					symbols: difficultyIcons,
+					symbols: difficultyIcons || "—",
 					skill,
 				});
 


### PR DESCRIPTION
This PR fixes the `@check[skill,0]` enricher showing up as `Simple [] skill check` and instead shows it as `Simple [—] skill check` akin to how the rulebooks display it.