### PR TITLE
Fix sheet tab styling bleeding into other apps

### DIFF
--- a/src/scss/nav.scss
+++ b/src/scss/nav.scss
@@ -1,7 +1,7 @@
 @use 'vars/colors';
 @use 'vars/sheet';
 
-.sheet {
+.sheet.genesys {
 	nav.sheet-tabs {
 		// Stretch the tabs container across the full sheet width.
 		margin-left: -1 * sheet.$padding;


### PR DESCRIPTION
This PR fixes tab bar styling being applied to other apps as general styling, rather than being contained to system-related sheets.