### PR TITLE
Fix archetype characteristic label missalignment

### DIFF
--- a/src/vue/components/character/Characteristic.vue
+++ b/src/vue/components/character/Characteristic.vue
@@ -85,7 +85,9 @@ const unmarkSuperCharacteristicLabel = game.i18n.localize('Genesys.Labels.Unmark
 					<i v-if="canUpgrade" class="fas fa-arrow-circle-up"></i>
 				</a>
 
-				<Localized v-else :label="label" />
+				<span v-else>
+					<Localized :label="label" />
+				</span>
 			</label>
 		</ContextMenu>
 
@@ -208,7 +210,7 @@ const unmarkSuperCharacteristicLabel = game.i18n.localize('Genesys.Labels.Unmark
 		margin-top: 2px;
 		margin-bottom: 2px;
 
-		a {
+		a, span {
 			display: flex;
 			flex-wrap: nowrap;
 			align-items: center;


### PR DESCRIPTION
This PR resolves an issue in the `Characteristic` component when the characteristic is not rollable that cause a misalignment in labels that are too long for the intended width by applying the same CSS structure that rollable characteristic labels have.

With Fix:
<img width="550" height="82" alt="image" src="https://github.com/user-attachments/assets/9f81f476-9f96-43cd-9eb1-ca44e2c0c471" />

Without Fix:
<img width="576" height="92" alt="image" src="https://github.com/user-attachments/assets/e801b8c8-aba8-4cf5-b0da-d2d3c9a326b7" />

Screenshots are provided in German language as the issue is more pronounced there, but the issue is present in all languages of course. English characteristic names just happen to be short enough that the only characteristic that is slightly suffering from this is willpower:
<img width="71" height="38" alt="image" src="https://github.com/user-attachments/assets/022473ab-1819-497a-bf87-144072a37da5" />

