### PR TITLE
fix: Apply roll mode to geneys dice rolls

### DIFF
--- a/src/dice/GenesysRoller.ts
+++ b/src/dice/GenesysRoller.ts
@@ -133,7 +133,7 @@ export default class GenesysRoller {
 			content: html,
 			rolls: [roll],
 		};
-		await ChatMessage.create(chatData);
+		await ChatMessage.create(chatData, { rollMode: game.settings.get('core', 'rollMode') });
 	}
 
 	static async attackRoll({


### PR DESCRIPTION
This PR applies the currently selected chat roll mode to dice rolls created through the Genesys Dice Roll prompt. Further down the line it would be nice to have an overwrite available directly in the dice prompt, but this provides a minimal working fix for now. Works with v12 and v13.